### PR TITLE
Recommended LycanitesTweaks 1.0.12 config

### DIFF
--- a/overrides/config/lycanitesmobs/general.cfg
+++ b/overrides/config/lycanitesmobs/general.cfg
@@ -28,13 +28,13 @@ altars {
 
     # If set to true, Altars will only activate in dimensions that the monster spawned or event started is allowed in.
     B:"Check Dimension"=false
-    D:"Damage Altar Stat Multiplier"=4.0
-    D:"Defense Altar Stat Multiplier"=4.0
-    D:"Effect Altar Stat Multiplier"=4.0
-    D:"Haste Altar Stat Multiplier"=4.0
-    D:"Health Altar Stat Multiplier"=10.0
-    D:"Pierce Altar Stat Multiplier"=4.0
-    D:"Speed Altar Stat Multiplier"=1.5
+    D:"Damage Altar Stat Multiplier"=2.0
+    D:"Defense Altar Stat Multiplier"=2.0
+    D:"Effect Altar Stat Multiplier"=2.0
+    D:"Haste Altar Stat Multiplier"=2.0
+    D:"Health Altar Stat Multiplier"=2.0
+    D:"Pierce Altar Stat Multiplier"=2.0
+    D:"Speed Altar Stat Multiplier"=1.0
 }
 
 

--- a/overrides/config/lycanitesmobs/mobevents/halloween_landspawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/halloween_landspawner.json
@@ -41,7 +41,15 @@
     {
       "mobId": "lycanitesmobs:ent",
       "weight": 8,
-      "mobNameTag": "Twisted Ent"
+      "mobNameTag": "Twisted Ent",
+      "mobDrops": [
+        {
+          "item": "lycanitestweaks:eventsoulstaff",
+          "amountMultiplier": false,
+          "bonusAmount": false,
+          "chance": 0.05
+        }
+      ]
     },
     {
       "mobId": "lycanitesmobs:treant",

--- a/overrides/config/lycanitesmobs/mobevents/halloween_skyspawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/halloween_skyspawner.json
@@ -46,7 +46,15 @@
     {
       "mobId": "lycanitesmobs:banshee",
       "weight": 4,
-      "mobNameTag": "Maniacal Ghost"
+      "mobNameTag": "Maniacal Ghost",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     },
     {
       "mobId": "lycanitesmobs:cacodemon",
@@ -59,12 +67,28 @@
     {
       "mobId": "lycanitesmobs:grue",
       "weight": 8,
-      "mobNameTag": "Shadow Clown"
+      "mobNameTag": "Shadow Clown",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     },
     {
       "mobId": "lycanitesmobs:epion",
       "weight": 4,
-      "mobNameTag": "Vampire Bat"
+      "mobNameTag": "Vampire Bat",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     }
   ]
 }

--- a/overrides/config/lycanitesmobs/mobevents/roasting_landspawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/roasting_landspawner.json
@@ -49,7 +49,15 @@
     {
       "mobId": "lycanitesmobs:wildkin",
       "weight": 8,
-      "mobNameTag": "Gooderness"
+      "mobNameTag": "Gooderness",
+      "mobDrops": [
+        {
+          "item": "lycanitestweaks:eventsoulstaff",
+          "amountMultiplier": false,
+          "bonusAmount": false,
+          "chance": 0.05
+        }
+      ]
     }
   ]
 }

--- a/overrides/config/lycanitesmobs/mobevents/rudolph_spawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/rudolph_spawner.json
@@ -41,12 +41,28 @@
     {
       "mobId": "lycanitesmobs:jabberwock",
       "weight": 8,
-      "mobNameTag": "Rudolph"
+      "mobNameTag": "Rudolph",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     },
     {
       "mobId": "lycanitesmobs:wildkin",
       "weight": 2,
-      "mobNameTag": "Gooderness"
+      "mobNameTag": "Gooderness",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     }
   ]
 }

--- a/overrides/config/lycanitesmobs/mobevents/saltytree_spawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/saltytree_spawner.json
@@ -41,7 +41,15 @@
     {
       "mobId": "lycanitesmobs:ent",
       "weight": 8,
-      "mobNameTag": "Salty Tree"
+      "mobNameTag": "Salty Tree",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     },
     {
       "mobId": "lycanitesmobs:treant",
@@ -51,7 +59,15 @@
     {
       "mobId": "lycanitesmobs:wildkin",
       "weight": 2,
-      "mobNameTag": "Gooderness"
+      "mobNameTag": "Gooderness",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     }
   ]
 }

--- a/overrides/config/lycanitesmobs/mobevents/satanclaws_spawner.json
+++ b/overrides/config/lycanitesmobs/mobevents/satanclaws_spawner.json
@@ -42,7 +42,15 @@
     {
       "mobId": "lycanitesmobs:reaper",
       "weight": 8,
-      "mobNameTag": "Satan Claws"
+      "mobNameTag": "Satan Claws",
+		"mobDrops": [
+			{
+				"item": "lycanitestweaks:eventsoulstaff",
+				"amountMultiplier": false,
+				"bonusAmount": false,
+				"chance": 0.05
+			}
+		]
     }
   ]
 }

--- a/overrides/config/lycanitesmobs/spawners/gem.json
+++ b/overrides/config/lycanitesmobs/spawners/gem.json
@@ -14,22 +14,16 @@
   "conditions": [],
   "triggers": [
     {
-      "type": "block",
+      "type": "ore",
       "onHarvest": false,
+      "ores": false,
+      "gems": true,
       "chance": 0.02,
       "blocks": [
-        "minecraft:quartz_ore",
-        "minecraft:diamond_ore",
-        "minecraft:lapis_ore",
-        "minecraft:redstone_ore",
-        "minecraft:emerald_ore",
-        "quark:biotite_ore",
-        "scalinghealth:crystalore",
-        "iceandfire:amethyst_ore",
-        "iceandfire:sapphire_ore",
-        "defiledlands:scarlite_ore",
-        "defiledlands:hephaestite_ore"
-      ]
+        "srparasites:gore"
+      ],
+      "blocksListType": "blacklist",
+      "blockMaterialsListType": "blacklist"
     }
   ],
   "locations": [

--- a/overrides/config/lycanitestweaks.cfg
+++ b/overrides/config/lycanitestweaks.cfg
@@ -9,23 +9,6 @@ general {
     B:"LycanitesTweaks Default JSON"=true
 
     ##########################################################################################################
-    # client options
-    #--------------------------------------------------------------------------------------------------------#
-    # Client-Side Options
-    ##########################################################################################################
-
-    "client options" {
-        # Logging for information that is automatic but not available every tick
-        B:"Debug Log Automatic Information"=false
-
-        # Logging for information that is manually triggered by players
-        B:"Debug Log Manual Trigger Information"=false
-
-        # Logging for information that can be dumped every tick
-        B:"Debug Log Tick Information"=false
-    }
-
-    ##########################################################################################################
     # server options
     #--------------------------------------------------------------------------------------------------------#
     # Server-Side Options
@@ -34,6 +17,179 @@ general {
     "server options" {
         # Whether Lycanites Block Protection protects against any Living Entity, not just players
         B:"Block Protection Living Event"=true
+
+        # Use the LivingSetAttackTargetEvent to prevent Fear entities from being targeted
+        B:"Enforce Fear Entity Target Blacklist"=true
+
+        ##########################################################################################################
+        # charge leveling experience
+        #--------------------------------------------------------------------------------------------------------#
+        # Manage the leveling calculation for anything that uses Charges to level up.
+        # Pets and Equipment configs are here as Vanilla Lycanites does not provide them.
+        # LycanitesTweaks feature configs are provided in their respective config group.
+        ##########################################################################################################
+
+        "charge leveling experience" {
+            # Modify leveling calculation for Vanilla Lycanites, allows the BASE_EXP to be configured for pets and equipment parts.
+            # The defaults will use Vanilla Lycanites between level 1-50, then swap to a slower growing calculation.
+            # Lycanites calc: [BASE * (1 + (lvl - 1) * LINEAR_MULT)]
+            # Optional Calc: [BASE * (1 + ln(lvl) * LOG_MULT)]
+            B:"0. Modify Charge Experience Calculation"=true
+
+            # Base EXP Required for equipment parts. Lycanites default is 500.
+            # Min: 1
+            # Max: 2147483647
+            I:"Experience Calculation - Base for Equipment Parts"=500
+
+            # Base EXP Required for pets. Lycanites default is 100.
+            # Min: 1
+            # Max: 2147483647
+            I:"Experience Calculation - Base for Pets"=100
+
+            # EXP Value of a single charge. Lycanites default is 50.
+            # Min: 1
+            # Max: 2147483647
+            I:"Experience Calculation - Charge EXP Value"=50
+
+            # Linear Multiplier for the Vanilla Lycanites calc. Default is 0.25, +25% of the BASE per level.
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"Experience Calculation - Linear Multiplier"=0.25
+
+            # Log Multiplier for the optional calc. Default values are set so the xp requirement is about equal when the formula swaps.
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"Experience Calculation - Log Multiplier"=3.15
+
+            # What level the slower growing log calc starts getting used. Set to 0 to disable and only use the vanilla calc.
+            I:"Experience Calculation - Log Start Level"=50
+        }
+
+        ##########################################################################################################
+        # custom staffs
+        #--------------------------------------------------------------------------------------------------------#
+        # Various staffs based on the current Summon Staffs and the older Scepters.
+        # Charge Staff - Essentially a bow that shoots Lycanites charges.
+        # Challenge Soul Staff - Dropped from Altar bosses, summons them as a temporary minion.
+        # Eventful Staff - Seasonal drop, basic Summoning Staff that always summons a specific minion.
+        ##########################################################################################################
+
+        "custom staffs" {
+            # Adds and registers the Challenge Soul Staff, a temporary single-use summon staff containing an Altar Mini-Boss.
+            # This is intended to be dropped by modified Mini-Boss Altars which use the extra stats that are defined, but never used in the Vanilla Lycanites config.
+            # A Challenge Soul Staff will be added to the drops of those bosses.
+            B:"0. Register Challenge Soul Staffs"=true
+
+            # Only provided a Challenge Staff drop if a Diamond or Emerald Soulkey is used.
+            # Recommended to use with "Altar Mini Boss Config Bonus Stats" and not use the default set of bonus stats.
+            B:"0. Register Challenge Soul Staffs - Diamond and Emerald Key"=true
+
+            # Adds and registers the Charge Staff, essentially a Vanilla Bow that uses Lycanites Charges as ammo.
+            # Allows many Bow bonuses and enchantments to apply to charge throwing in a simple manner.
+            B:"0. Register Charge Staffs"=true
+
+            # Adds and registers the Eventful Staff, summoning staffs that drop from the Seasonal Event mobs to summon them as minions.
+            # Drops are only automatically added if the event JSON configs are loading the default settings.
+            # Drop rate and applicable mobs can be edited, base is 5% drop rate for each custom name mob.
+            B:"0. Register Eventful Staffs"=true
+
+            # Summon Duration in seconds for Challenge Soul Staff minions, basic Summoning Staff minions last for 60 seconds.
+            I:"Challenge Soul Staff - Summon Duration"=300
+
+            # List of enchants to blacklist from being applicable to Charge Staffs
+            # Format: [modid: path]
+            S:"Charge Staff Enchantments Blacklist" <
+                minecraft:infinity
+                minecraft:flame
+                minecraft:punch
+                mujmajnkraftsbettersurvival:arrowrecovery
+                mujmajnkraftsbettersurvival:blast
+                mujmajnkraftsbettersurvival:multishot
+                somanyenchantments:lesserflame
+                somanyenchantments:advancedflame
+                somanyenchantments:supremeflame
+                somanyenchantments:advancedpunch
+                somanyenchantments:rune_arrowpiercing
+                somanyenchantments:splitshot
+             >
+
+            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
+            # This toggle controls whether these arrows can persist to apply effects that charge projectiles are unable to copy, such as knockback properties.
+            B:"Charge Staffs Arrows"=false
+
+            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
+            # This toggle controls whether these arrows teleport every tick to the charge the arrow is linked to.
+            B:"Charge Staffs Arrows Follow Charge"=false
+
+            # Whether Charge Staffs can have enchantments
+            B:"Charge Staffs Enchantability"=true
+        }
+
+        ##########################################################################################################
+        # additional loot
+        #--------------------------------------------------------------------------------------------------------#
+        # Manage the ability to use vanilla loot tables (accessible via resource packs or loottweaker) for Lycanite entities.
+        # Toggles the use of JSON loot tables for Bosses meant to provide Emeralds, XP Bottles, and Enchanted Book that reflect Boss' Levels.
+        # Adjust a dynamic loot table that allows mobs to drop any charge from the entities' set of element properties.
+        ##########################################################################################################
+
+        "additional loot" {
+            # Lycanites Creatures can use JSON loot tables alongside Lycanites Mobs drop list - required for the added loot tables here
+            B:"0. Vanilla Lootables for Lycanites Mobs"=true
+
+            # Level scale to determine the upper bound of bonus drops per mob level, lower bound is always 0.0
+            # 1.0 means the upper bound is 100% the mob's level, up to 10 drops for lvl 10.
+            # 0.5 is 50% the mob's level, so 15 drops for a lvl 30.
+            #  + 0.1 is 10% the mob's level, so 5 drops for a lvl 50.
+            D:"Random Charge Level Scale"=0.1
+
+            # Limit the number of total items to drop, calculated after level bonus, set to 0 to have no limit
+            I:"Random Charge Loot Drop Limit"=1728
+
+            # How many charges to drop at maximum before any bonus drops
+            I:"Random Charge Loot Maximum Count"=1
+
+            # How many charges to drop at minimum
+            I:"Random Charge Loot Minimum Count"=1
+
+            # Minimum Creature Level for the lycanite mob to drop Random Charges
+            I:"Random Charge Loot Minimum Mob Level"=0
+
+            # How many charges per looting lvl to add on top at max (will roll a random amount between 0 and this number times looting lvl). Set to 0 to disable
+            I:"Random Charge Looting Bonus"=0
+
+            # Register Level 100+ Amalgalich, Asmodeus, and Rahovart special Enchanted Soulkey drop
+            B:"Register Boss Soulkey Loot Tables"=true
+
+            # Register Loot Tables for Amalgalich, Asmodeus, and Rahovart that are scaled to Mob Levels
+            B:"Register Boss With Levels Loot Tables"=true
+
+            # Register Loot Tables for creatures dropping random charges of their element (This LootTable is dynamic)
+            B:"Register Random Charges Loot Tables"=true
+
+            # Register Loot Tables for any creature tagged as SpawnedAsBoss (ex Dungeon/Modified Altar)
+            # Basic configurable number of randomly enchanted books.
+            B:"Register SpawnedAsBoss Enchant Randomly Book Loot Tables"=false
+
+            # Register Loot Tables for any creature tagged as SpawnedAsBoss (ex Dungeon/Modified Altar)
+            # One non treasure enchanted book drop where the enchantWithLevels loot func is applied with 100% of the Boss' level.
+            # One treasure enchanted book where enchantWithLevels loot func is applied with 75% of the Boss' level.
+            B:"Register SpawnedAsBoss With Levels Loot Tables"=true
+
+            # Percent of bonus XP to provide per mob's level. Set to 0 to disable.
+            D:"Scale XP Drop With Levels"=0.029999999329447746
+
+            # Whether the main bosses use the Lycanites Config "Variant Rare Experience Scale"
+            B:"Scale XP Drop With Levels - Main Boss Bonus"=true
+
+            # Whether SpawnedAsBoss mobs use the Lycanites Config "Variant Rare Experience Scale"
+            B:"Scale XP Drop With Levels - SpawnedAsBoss Bonus"=true
+
+            # How many books should drop from the "SpawnedAsBoss Enchant Randomly Book" Loot Table
+            # Consider how applying this tag is configured.
+            # Dungeons always have this tag, altar mini bosses can be configured, and if random boss spawns are enabled.
+            I:"SpawnedAsBoss Enchant Randomly Book Count"=2
+        }
 
         ##########################################################################################################
         # additional altars
@@ -132,47 +288,6 @@ general {
         }
 
         ##########################################################################################################
-        # custom staffs
-        #--------------------------------------------------------------------------------------------------------#
-        # Various staffs based on the current Summon Staffs and the older Scepters.
-        # Charge Staff - Essentially a bow that shoots Lycanites charges.
-        ##########################################################################################################
-
-        "custom staffs" {
-            # Adds and registers the Charge Staff, essentially a Vanilla Bow that uses Lycanites Charges as ammo.
-            # Allows many Bow bonuses and enchantments to apply to charge throwing in a simple manner.
-            B:"0. Register Charge Staffs"=true
-
-            # List of enchants to blacklist from being applicable to Charge Staffs
-            # Format: [modid: path]
-            S:"Charge Staff Enchantments Blacklist" <
-                minecraft:infinity
-                minecraft:flame
-                minecraft:punch
-                mujmajnkraftsbettersurvival:arrowrecovery
-                mujmajnkraftsbettersurvival:blast
-                mujmajnkraftsbettersurvival:multishot
-                somanyenchantments:lesserflame
-                somanyenchantments:advancedflame
-                somanyenchantments:supremeflame
-                somanyenchantments:advancedpunch
-                somanyenchantments:rune_arrowpiercing
-                somanyenchantments:splitshot
-             >
-
-            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
-            # This toggle controls whether these arrows can persist to apply effects that charge projectiles are unable to copy, such as knockback properties.
-            B:"Charge Staffs Arrows"=false
-
-            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
-            # This toggle controls whether these arrows teleport every tick to the charge the arrow is linked to.
-            B:"Charge Staffs Arrows Follow Charge"=false
-
-            # Whether Charge Staffs can have enchantments
-            B:"Charge Staffs Enchantability"=true
-        }
-
-        ##########################################################################################################
         # enchanted soulkey
         #--------------------------------------------------------------------------------------------------------#
         # Enchanted Soulkeys are a better version of existing Soulkeys.
@@ -198,13 +313,10 @@ general {
             B:"0. Works for Altar Mini Bosses"=true
 
             # Base charge experience required to level up the key. Increases by 25% per level of the key until the max is reached. Each Lycanites Charge gives 50 experience
-            I:"Base Levelup Experience"=500
+            I:"Base Levelup Experience"=100
 
             # Default Maximum Creature Level for mobs that can be summoned with the key. Can be overriden with NBT
             I:"Max Creature Level"=100
-
-            # Leveling up the key will never cost more than this amount of charge experience.
-            I:"Max Levelup Experience"=2500
 
             # Enchanted Soulkeys will not be able to store more than this amount of nether stars / gem blocks as usages.
             I:"Max Usages"=1000
@@ -213,126 +325,6 @@ general {
             I:"Usages On Craft"=8
         }
 
-        ##########################################################################################################
-        # additional loot
-        #--------------------------------------------------------------------------------------------------------#
-        # Manage the ability to use vanilla loot tables (accessible via resource packs or loottweaker) for Lycanite entities.
-        # Toggles the use of JSON loot tables for Bosses meant to provide Emeralds, XP Bottles, and Enchanted Book that reflect Boss' Levels.
-        # Adjust a dynamic loot table that allows mobs to drop any charge from the entities' set of element properties.
-        ##########################################################################################################
-
-        "additional loot" {
-            # Lycanites Creatures can use JSON loot tables alongside Lycanites Mobs drop list - required for the added loot tables here
-            B:"0. Vanilla Lootables for Lycanites Mobs"=true
-
-            # Level scale to determine the upper bound of bonus drops per mob level, lower bound is always 0.0
-            # 1.0 means the upper bound is 100% the mob's level, up to 10 drops for lvl 10.
-            # 0.5 is 50% the mob's level, so 15 drops for a lvl 30.
-            #  + 0.1 is 10% the mob's level, so 5 drops for a lvl 50.
-            D:"Random Charge Level Scale"=0.5
-
-            # Limit the number of total items to drop, calculated after level bonus, set to 0 to have no limit
-            I:"Random Charge Loot Drop Limit"=1728
-
-            # How many charges to drop at maximum before any bonus drops
-            I:"Random Charge Loot Maximum Count"=5
-
-            # How many charges to drop at minimum
-            I:"Random Charge Loot Minimum Count"=0
-
-            # Minimum Creature Level for the lycanite mob to drop Random Charges
-            I:"Random Charge Loot Minimum Mob Level"=0
-
-            # How many charges per looting lvl to add on top at max (will roll a random amount between 0 and this number times looting lvl). Set to 0 to disable
-            I:"Random Charge Looting Bonus"=1
-
-            # Register Level 100+ Amalgalich, Asmodeus, and Rahovart special Enchanted Soulkey drop
-            B:"Register Boss Soulkey Loot Tables"=true
-
-            # Register Loot Tables for Amalgalich, Asmodeus, and Rahovart that are scaled to Mob Levels
-            B:"Register Boss With Levels Loot Tables"=true
-
-            # Register Loot Tables for creatures dropping random charges of their element (This LootTable is dynamic)
-            B:"Register Random Charges Loot Tables"=true
-
-            # Register Loot Tables for any creature tagged as SpawnedAsBoss (ex Dungeon/Modified Altar)
-            # Basic configurable number of randomly enchanted books.
-            B:"Register SpawnedAsBoss Enchant Randomly Book Loot Tables"=false
-
-            # Register Loot Tables for any creature tagged as SpawnedAsBoss (ex Dungeon/Modified Altar)
-            # One non treasure enchanted book drop where the enchantWithLevels loot func is applied with 100% of the Boss' level.
-            # One treasure enchanted book where enchantWithLevels loot func is applied with 75% of the Boss' level.
-            # One Bottle o' Enchanting per 2 levels.
-            B:"Register SpawnedAsBoss With Levels Loot Tables"=true
-
-            # How many books should drop from the "SpawnedAsBoss Enchant Randomly Book" Loot Table
-            # Consider how applying this tag is configured.
-            # Dungeons always have this tag, altar mini bosses can be configured, and if random boss spawns are enabled.
-            I:"SpawnedAsBoss Enchant Randomly Book Count"=2
-        }
-
-    }
-
-    ##########################################################################################################
-    # client mixins
-    #--------------------------------------------------------------------------------------------------------#
-    # Mixins based Client Tweaks
-    ##########################################################################################################
-
-    "client mixins" {
-        # Dependency for adding new/hiding Beastiary information. Required for server-side to know what Creature players have selected.
-        B:"0. Modify Beastiary Information"=true
-
-        # Adds a tab for Lycanites Altar renders and block counts
-        B:"0.a Lycanites Mobs Altar Beastiary Tab"=true
-
-        # Adds a tab to show Player Mob Levels information
-        B:"0.a LycanitesTweaks Player Mob Levels Beastiary Tab"=true
-
-        # Enables the ability for the Equipment Infuser and Station to display progress bars for additional items
-        # Ex. LycanitesTweaks Enchanted Soulkeys and Modified Summoning Staffs.
-        B:"1. Infuser and Display Additional Items"=true
-
-        # Case sensitive blacklist for hiding any Altar by name. Does not affect gameplay.
-        S:"Altar Display Blacklist" <
-         >
-
-        # Case sensitive blacklist for hiding any Creature by name. Does not affect gameplay.
-        # Used by Lycanites Tweaks to hide easter eggs.
-        S:"Creature Display Blacklist" <
-            sonofamalgalich
-         >
-
-        # Case sensitive blacklist for hiding any Creature Subspecies by name. Does not affect gameplay.
-        # Used by Lycanites Tweaks to hide easter eggs.
-        # 	Format: [creatureName: subspeciesIndex]
-        S:"Creature Subspecies Display Blacklist" <
-            darkling: 111
-         >
-
-        # Case sensitive blacklist for hiding any Element by name. Does not affect gameplay.
-        S:"Element Display Blacklist" <
-            nightmare
-            viral
-         >
-
-        # Adds stats on Summoning tab that shows Imperfect Summoning information
-        B:"LycanitesTweaks Imperfect Summoning Tab"=true
-
-        # PML Beastiary Render order is determined by the order of this list.
-        # 	categoryName - Spelling must match 'Bonus Categories' entries else hidden
-        # This will be compared to the existence of 'Bonus Categories' entries in the PML config
-        S:"Player Mob Levels Category Display Order" <
-            AltarBossMain
-            AltarBossMini
-            DungeonBoss
-            SpawnerNatural
-            SpawnerTile
-            SpawnerTrigger_
-            EncounterEvent_
-            SoulboundTame_
-            SummonMinion
-         >
     }
 
     ##########################################################################################################
@@ -342,6 +334,364 @@ general {
     ##########################################################################################################
 
     "major features mixins" {
+
+        ##########################################################################################################
+        # player mob levels bonus
+        #--------------------------------------------------------------------------------------------------------#
+        # Capability to store contextual information about a player and apply a contextual boost of levels to a Lycanites.
+        # Works together with Lycanites' Beastiary and player gear in order to determine boosts for hostile/tamed contexts.
+        # There are many calculation options and contexts to adjust, tamed contexts are affected more by Beastiary while hostile are affected by gear.
+        # Overall intended to provide passive progression with a few opt-in challenges without overwhelming a player with tough mobs.
+        ##########################################################################################################
+
+        "player mob levels bonus" {
+            # Enable Capability to calculate a Mob Level associated to a player
+            B:"0. Player Mob Levels"=true
+
+            # The primary opt-out option, allows players to set final total 0-100% modifiers for a single or every creature.
+            #  This affects the server-side calculation and removes the client-side Beastiary buttons.
+            B:"0.a Set Creature Modifiers In Beastiary"=true
+
+            # Format: [categoryName, soulgazer, bonusGroup, multiplier]
+            # 	categoryName - The case player mob levels is added, do not change from the defaults
+            # 	soulgazer - If a mainhand/bauble Soulgazer is required to apply level boost
+            # 	bonusGroup - [All,TAMED,WILD], specifies the list of multipliers to use when calculating bonus levels
+            # 	multiplier - Multiplier to use on the total bonus before it is used
+            # 
+            # Removing an entry fully disables associated features compared to zero'ing the multiplier
+            # 	ex. 'SpawnerTrigger' will still flag first-time spawns with 0.0 multiplier
+            S:"Bonus Categories" <
+                AltarBossMain, true, WILD, 1.0
+                AltarBossMini, true, WILD, 0.75
+                DungeonBoss, true, WILD, 0.75
+                EncounterEvent, false, WILD, 1.0
+                SoulboundTame, false, TAMED, 1.0
+                SpawnerNatural, false, ALL, 0.2
+                SpawnerTile, false, WILD, 0.3
+                SpawnerTrigger, false, WILD, 0.2
+                SummonMinion, false, TAMED, 1.0
+                SummonMinionInstant, false, TAMED, 0.5
+             >
+
+            # Specifies multipliers on specific bonus sources. Fall back list for when Tamed/Wild values are not found.
+            # Format: [bonusName, multiplier]
+            # 	bonusName - The Source of the bonus, do not change from the defaults
+            # 	multiplier - Multiplier to use on the total bonus before it is used
+            S:"Bonus Source Multipliers - ALL" <
+                ActivePet, 0.75
+                BestiaryCreature, 1.0
+                BestiaryElement, 1.0
+                Enchantments, 1.0
+                PlayerDeath, -1.0
+             >
+
+            # Specifies multipliers on specific bonus sources. Used on Bonus Categories that are marked as 'TAMED'
+            # Format: [bonusName,multiplier]
+            # 	bonusName - The Source of the bonus, do not change from the defaults
+            # 	multiplier - Multiplier to use on the total bonus before it is used
+            S:"Bonus Source Multipliers - TAMED" <
+                ActivePet, 0.25
+                BestiaryCreature, 2.0
+                BestiaryElement, 2.0
+                Enchantments, 0.5
+                PlayerDeath, 0.0
+             >
+
+            # Specifies multipliers on specific bonus sources. Used on Bonus Categories that are marked as 'WILD'
+            # Format: [bonusName,multiplier]
+            # 	bonusName - The Source of the bonus, do not change from the defaults
+            # 	multiplier - Multiplier to use on the total bonus before it is used
+            S:"Bonus Source Multipliers - WILD" <
+                ActivePet, 1.0
+                BestiaryCreature, 1.0
+                BestiaryElement, 0.0
+                Enchantments, 1.0
+                PlayerDeath, -1.0
+             >
+
+            # Whether highest level Pet Entry should try to be calculated, unsorted levels are still stored, false always returns 0.
+            # This is different from the level of the currently active pets.
+            B:"Calculate Highest Level Pet Entry"=true
+
+            # Used to lower bloated Minimum Enchantibility values via Rarity {COMMON, UNCOMMON, RARE, VERY_RARE}
+            I:"Enchantment Rarity Divisors" <
+                1
+                2
+                5
+                10
+             >
+
+            # Inject handling for Player Mob Level affecting JSON Spawners by whitelist
+            B:"JSON Spawner Bonus"=true
+
+            # JSON Spawner Names is a blacklist instead of whitelist
+            B:"JSON Spawner Bonus - Blacklist"=false
+
+            # Flags JSON entities to not be affected by the Natural Spawn Boost whether or not an entity was boosted.
+            # This can make every event provide a smaller boost or make a few events stack a large boost
+            B:"JSON Spawner Bonus - Calls First Spawn"=false
+
+            # Apply the PML boost to all Mob Events that use Spawner JSONs
+            B:"JSON Spawner Bonus - Mob Events"=true
+
+            # List of Lycanites Spawner Names to attempt to apply Player Mob Levels
+            S:"JSON Spawner Bonus - Spawner Names" <
+                chaos
+                disruption
+                sleep
+             >
+
+            # Inject handling for Player Mob Levels affecting the main Bosses
+            B:"Main Boss Bonus"=true
+
+            # Remove treat pacifying and lower reputation gain when taming high leveled creatures
+            B:"Over Leveled Penalty"=true
+
+            # Creature level to compare to PML highest pet entry level, set to 0 to disable
+            I:"Over Leveled Penalty - Start"=20
+
+            # Whether treat reputation will be penalized if creature is over leveled.
+            B:"Over Leveled Penalty - Treat Point Penalty"=false
+
+            # If creature could be tempted, will it remain able to be tempted if over leveled
+            B:"Over Leveled Penalty - Treat Tempt"=false
+
+            # Lycanites Pet Manager updates Player Mob Level Capability with pet entry information
+            B:"Pet Manager Tracks Pet Levels"=true
+
+            # Inject handling for Player Mob Level to affect summiniong minions through Equipment melee, Spriggan Heart, and Lob Darklings minions
+            B:"Player Mob Level Summon Instant Minion"=true
+
+            # Inject handling for Player Mob Level to affect summon staff minions
+            B:"Player Mob Level Summon Staff"=true
+
+            # Whether weakened soulbound inventory GUIs are unable to be accessed
+            B:"Soulbound Weakened Dimensions - Disable Inventory"=true
+
+            # Whether weakened soulbounds are unable to be mounted
+            B:"Soulbound Weakened Dimensions - Disable Mounting"=true
+
+            # Whether weakened dimensions prevent soulbound spirit recharge
+            B:"Soulbound Weakened Dimensions - Disable Spirit Recharge"=true
+
+            # Dimension IDs where soulbounds are level capped at Player Mob Level
+            I:"Soulbound Weakened Dimensions - IDs" <
+                111
+                3
+             >
+
+            # Whether weakened soulbounds can spawn in dimensions blacklisted by vanilla Lycanites.
+            # Lazy option that can be hot swapped in game.
+            B:"Soulbound Weakened Dimensions - Overrules Blacklist"=true
+
+            # Soulbound Weakened Dimensions is Whitelist
+            B:"Soulbound Weakened Dimensions - Whitelist"=true
+
+            # Inject handling for soulbounds to have limited Player Mob Level bonuses in specified dimensions.
+            # Prone to desyncs without 'Fix Client Pet Stat Desync'
+            # Will fail without 'Fix Properties Set After Stat Calculation'
+            B:"Soulbounds Weakened In Specific Dimensions"=true
+        }
+
+        ##########################################################################################################
+        # tweak creature stats
+        #--------------------------------------------------------------------------------------------------------#
+        # Various options to balance stats and debuff.
+        # Additional modifiers for Bosses, such as summoning level matching minions and nbt SpawnedAsBoss tag providing Rare Variant Stats.
+        # LycanitesTweaks caps speed/piercing and certain debuffs as high values don't provide a fair experience.
+        # Boss modifiers address high health bonuses + Boss Damage Limit being not fun.
+        ##########################################################################################################
+
+        "tweak creature stats" {
+            # Dependency for usings caps on bonus stats per level. Does not affect variant/NBT bonuses.
+            B:"0. Cap Specific Stats"=true
+
+            # Ratio of max bonus defense, set to 0 to disable the cap
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"0.a Defense Ratio"=4.0
+
+            # Ratio of max bonus effect duration, set to 0 to disable the cap
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"0.a Effect Duration Ratio"=5.0
+
+            # Ratio of max bonus movement speed, set to 0 to disable the cap
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"0.a Movement Speed Ratio"=3.0
+
+            # Ratio of max bonus pierce, set to 0 to disable the cap
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"0.a Pierce Ratio"=3.0
+
+            # List of elements that are blacklisted from applying their buffs. In vanilla Lycanites, Wisps are the only mobs who apply buffs.
+            # Soulgazers providing buffs when used on tamed pets check this.
+            # Buffs that have no functions and textures should be blacklisted.
+            # Format: [elementName]
+            S:"0.b Elements' Buffs - Blacklisted Elements" <
+                frost
+                lava
+                lightning
+                poison
+                arcane
+                fae
+                order
+             >
+
+            # List of elements whose Buffs will have capped level scaling. In vanilla Lycanites, Wisps are the only mobs who apply buffs.
+            # Soulgazers providing buffs when used on tamed pets check this.
+            # Format: [elementName, maxScaleLevel]
+            # 	elementName - Name of the element to limit, must be all lowercase
+            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
+            S:"0.b Elements' Buffs Level Limit" <
+                arbour, 15
+                earth, 15
+             >
+
+            # List of elements whose Debuffs will have capped level scaling.
+            # Format:[elementName, maxScaleLevel]
+            # 	elementName - Name of the element to limit, must be all lowercase
+            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
+            S:"0.b Elements' Debuffs Level Limit" <
+                arcane, 15
+                chaos, 15
+                lightning, 15
+                phase, 15
+             >
+
+            # List of various Lycanites that apply effects and toggle-able level scaling cap.
+            # Format:[thing, maxScaleLevel, enable]
+            # 	thing - Do not change from defaults
+            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
+            # 	enable - 'true' Will use the level limit
+            S:"0.b Misc Effects Level Limit" <
+                barghest, 15, false
+                cockatrice, 15, true
+                eechetik, 15, false
+                quetzodracl, 15, false
+                raiko, 15, false
+                shade, 15, true
+                strider, 15, false
+                warg, 15, true
+                EffectAuraGoal, 15, true
+             >
+
+            # Dependency for toggles. Only affects per level bonus, does not modify variant or nbt bonuses.
+            B:"1. Swap Health & Damage Per Level Bonus"=true
+
+            # Any Hostile Minions, such as those of the main bosses and rare variants
+            B:"1.a Hostile Minions"=true
+
+            # Rahovart, Asmodeus, and Amalgalich
+            B:"1.a Main Bosses"=true
+
+            # Anything tagged with SpawnedAsBoss such as Dungeon Bosses
+            B:"1.a Tagged Boss"=true
+
+            # Any Tamed Mobs. Intended for all players' mobs to feel more impactful but still trade 1 for 1.
+            B:"1.a Tamed Mobs"=true
+
+            # Dependency for modifying. Only affects per level bonus, does not modify variant or nbt bonuses.
+            B:"2. Modify Total Boss Health Per Level Bonus"=true
+
+            # Rahovart, Asmodeus, and Amalgalich. Intended to balance the Boss Damage Limit.
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"2.a Main Boss Total Ratio"=0.5
+
+            # Anything tagged with SpawnedAsBoss such as Dungeon Bosses. Intended to balance when the Boss Damage Limit is applied.
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"2.a Tagged Boss Excluding Rare Total Ratio"=0.5
+
+            # Intended when Dungeon Bosses only have the Boss Damage Limit when Rare.
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"2.a Tagged Boss Exclusively Rare Total Ratio"=0.5
+
+            # Vanilla Lycanites does not use the various "Altar Stat Multiplier" config settings, this will enable them.
+            # LycanitesTweaks provides the Challenge Soul Summoning Staff and SpawnedAsBoss loot as reasons increase the difficulty.
+            # Recommended to have "Sync Missing Properties" patch enabled to sync stats to Client.
+            B:"Altar Mini Boss Config Bonus Stats"=true
+
+            # Only apply the Bonus Stats if a Diamond or Emerald Soulkey is used.
+            B:"Altar Mini Boss Config Bonus Stats - Diamond and Emerald Key"=true
+
+            # Whether Altar Mini Bosses should be tagged with the SpawnedAsBoss NBT to interact with LycanitesTweaks features.
+            # Unlike Dungeon Bosses, this tag is not used for correcting boss stat balance and is mostly used for Loot Table checks.
+            B:"Altar Mini Boss SpawnedAsBoss NBT Tag"=true
+
+            # Only apply the SpawnedAsBoss NBT if a Diamond or Emerald Soulkey is used.
+            B:"Altar Mini Boss SpawnedAsBoss NBT Tag - Diamond and Emerald Key"=true
+
+            # Rahovart/Asmodeus mechanic based minions match the boss' levels
+            B:"Minion Level Matches Host - Boss Mechanics"=true
+
+            # Summon minion goal matches levels (AI Goal/Most Mobs). Amalgalich minions use this.
+            B:"Minion Level Matches Host - Entity Summon Goal"=true
+
+            # Lazy option to force dungeon configs to follow the Rare variant stat rebalancing.
+            # This will IGNORE dungeon configs and logs anytime it does so.
+            # It is recommended to set "loadDefault" to "true" or change manually.
+            # Default Lycanites distributes Bosses between level 10-250. This will result in 10 levels per config dungeonLevel, between 20-50
+            B:"Override Dungeon Boss Config Level"=false
+
+            # List of potion resource locations that Lycanites bosses will be fully immune to
+            S:"Potion Immunities - Bosses" <
+                lycanitestweaks:consumed
+                lycanitestweaks:voided
+                srparasites:coth
+             >
+
+            # List of potion resource locations that Lycanites minions of players and bosses will be fully immune to
+            S:"Potion Immunities - Minions" <
+                srparasites:coth
+             >
+
+            # Option to allow SpawnedAsBoss tagged mobs to naturally spawn, intended to simulate the random Rare Variant experience for every mob.
+            # Min: 0.0
+            # Max: 1.0
+            D:"Spawned As Boss Tagged Natural Spawns - Chance"=0.0044999998062849045
+
+            # Try to store naturally spawned SpawnedAsBoss entities in an Encounter Crystal.
+            # Used as a way to both hide the boss bar and indicate a Boss entity.
+            B:"Spawned As Boss Tagged Natural Spawns - Encounter Crystal"=true
+
+            # Sever side control of whether red boss bars should be hidden for non persistent SpawnedAsBoss mobs.
+            # This is similar to the vanilla Lycanites option to hide Rare Variant green boss bars.
+            B:"Spawned As Boss Tagged Natural Spawns - Hide Boss Bar"=false
+
+            # Server side count of the langkey "creature.spawnedasboss.prefix.n", which is used to add a prefix to boss names.
+            # Min: 0
+            # Max: 2147483647
+            I:"Spawned As Boss Tagged Natural Spawns - Random Names"=8
+
+            # Grant all lycanites tagged as SpawnedAsBoss the Boss Damage Limit mechanic.
+            # This is part of providing consistency across Dungeon Bosses as only Rare Variants had this mechanic.
+            # Vanilla Lycanites does not use this tag outside of Dungeons.
+            # There are some cases where this is intentionally overridden, such Enhanced Asmodeus' Astaroths
+            B:"Spawned As Boss Tagged Uses Boss Damage Limit"=true
+
+            # Grant all lycanites tagged as SpawnedAsBoss the Rare variant stat multipliers instead of the Common/Uncommon.
+            # This will automatically attempt to rebalance Dungeon Bosses that try to load default configs.
+            # Default Lycanites distributes Bosses between level 10-250. This will result in 10 levels per config dungeonLevel, between 20-50.
+            # This will also enable non persistent peaceful category (Chupa and Pinky) SpawnedAsBoss mobs to despawn naturally.
+            B:"Spawned As Boss Tagged Uses Rare Stats"=true
+
+            # Any mob summoned via staff or pedestal. Used as a reward for rank 2 knowledge with the imperfect summoning rework.
+            B:"Stat Bonus Receivers - Player Summoned Minions"=true
+
+            # Any mob given a Soulstone or from one
+            B:"Stat Bonus Receivers - Soulbounded Pets"=true
+
+            # Any mob tamed with treats
+            B:"Stat Bonus Receivers - Tamed With Treats"=true
+
+            # Dependency for toggles. Vanilla Lycanites erroneously allowed Soulbounds via oversight.
+            B:"Variant/NBT Stat Bonus Receivers"=true
+        }
 
         ##########################################################################################################
         # creature interactions
@@ -367,6 +717,9 @@ general {
 
             # Multiplier on total level scaled speed. Lycanites uses 1.25 for vertical movement.
             D:"Flying Mount Level Boosted Horizontal Speed - Modifier"=1.25
+
+            # Similar to the Equipment Infuser, allow the inventory slots of pets to consume charges to level up in bulk.
+            B:"Level Up Pets From Inventory"=true
 
             # Allow mounts to be use vanilla saddles based on levels
             B:"Mount with Vanilla Saddles"=true
@@ -500,8 +853,11 @@ general {
             # Prevent creatures with No Clip movement
             B:"Vehicle Anti Cheese - NoClip"=true
 
+            # Prevent creatures who are temporary minions. Applies to player owned and hostiles.
+            B:"Vehicle Anti Cheese - Temporary"=true
+
             # Transform if Can Transform Into Boss Flag
-            B:"Vehicle Anti Cheese - Transform Into Boss"=true
+            B:"Vehicle Anti Cheese - Transform Into Boss"=false
         }
 
         ##########################################################################################################
@@ -540,157 +896,6 @@ general {
             # Min: 1
             # Max: 2147483647
             I:"Encounter Crystal Mob Event - Spawn Chance"=50
-        }
-
-        ##########################################################################################################
-        # player mob levels bonus
-        #--------------------------------------------------------------------------------------------------------#
-        # Capability to store contextual information about a player and apply a contextual boost of levels to a Lycanites.
-        # Works together with Lycanites' Beastiary and player gear in order to determine boosts for hostile/tamed contexts.
-        # There are many calculation options and contexts to adjust, tamed contexts are affected more by Beastiary while hostile are affected by gear.
-        # Overall intended to provide passive progression with a few opt-in challenges without overwhelming a player with tough mobs.
-        ##########################################################################################################
-
-        "player mob levels bonus" {
-            # Enable Capability to calculate a Mob Level associated to a player
-            B:"0. Player Mob Levels"=true
-
-            # The primary opt-out option, allows players to set final total 0-100% modifiers for a single or every creature.
-            #  This affects the server-side calculation and removes the client-side Beastiary buttons.
-            B:"0.a Set Creature Modifiers In Beastiary"=true
-
-            # Format: [categoryName, soulgazer, bonusGroup, multiplier]
-            # 	categoryName - The case player mob levels is added, do not change from the defaults
-            # 	soulgazer - If a mainhand/bauble Soulgazer is required to apply level boost
-            # 	bonusGroup - [All,TAMED,WILD], specifies the list of multipliers to use when calculating bonus levels
-            # 	multiplier - Multiplier to use on the total bonus before it is used
-            # 
-            # Removing an entry fully disables associated features compared to zero'ing the multiplier
-            # 	ex. 'SpawnerTrigger' will still flag first-time spawns with 0.0 multiplier
-            S:"Bonus Categories" <
-                AltarBossMain, true, WILD, 1.0
-                AltarBossMini, true, WILD, 0.75
-                DungeonBoss, true, WILD, 0.75
-                EncounterEvent, false, WILD, 1.0
-                SoulboundTame, false, TAMED, 1.0
-                SpawnerNatural, false, ALL, 0.2
-                SpawnerTile, false, WILD, 0.3
-                SpawnerTrigger, false, WILD, 0.2
-                SummonMinion, false, TAMED, 1.0
-             >
-
-            # Specifies multipliers on specific bonus sources. Fall back list for when Tamed/Wild values are not found.
-            # Format: [bonusName, multiplier]
-            # 	bonusName - The Source of the bonus, do not change from the defaults
-            # 	multiplier - Multiplier to use on the total bonus before it is used
-            S:"Bonus Source Multipliers - ALL" <
-                ActivePet, 0.75
-                BestiaryCreature, 1.0
-                BestiaryElement, 1.0
-                Enchantments, 1.0
-                PlayerDeath, -1.0
-             >
-
-            # Specifies multipliers on specific bonus sources. Used on Bonus Categories that are marked as 'TAMED'
-            # Format: [bonusName,multiplier]
-            # 	bonusName - The Source of the bonus, do not change from the defaults
-            # 	multiplier - Multiplier to use on the total bonus before it is used
-            S:"Bonus Source Multipliers - TAMED" <
-                ActivePet, 0.25
-                BestiaryCreature, 2.0
-                BestiaryElement, 2.0
-                Enchantments, 0.5
-                PlayerDeath, 0.0
-             >
-
-            # Specifies multipliers on specific bonus sources. Used on Bonus Categories that are marked as 'WILD'
-            # Format: [bonusName,multiplier]
-            # 	bonusName - The Source of the bonus, do not change from the defaults
-            # 	multiplier - Multiplier to use on the total bonus before it is used
-            S:"Bonus Source Multipliers - WILD" <
-                ActivePet, 1.0
-                BestiaryCreature, 1.0
-                BestiaryElement, 0.0
-                Enchantments, 1.0
-                PlayerDeath, -1.0
-             >
-
-            # Whether highest level Pet Entry should try to be calculated, unsorted levels are still stored, false always returns 0.
-            # This is different from the level of the currently active pets.
-            B:"Calculate Highest Level Pet Entry"=true
-
-            # Used to lower bloated Minimum Enchantibility values via Rarity {COMMON, UNCOMMON, RARE, VERY_RARE}
-            I:"Enchantment Rarity Divisors" <
-                1
-                2
-                5
-                10
-             >
-
-            # Inject handling for Player Mob Level affecting JSON Spawners by whitelist
-            B:"JSON Spawner Bonus"=true
-
-            # JSON Spawner Names is a blacklist instead of whitelist
-            B:"JSON Spawner Bonus - Blacklist"=false
-
-            # Flags JSON entities to not be affected by the Natural Spawn Boost whether or not an entity was boosted.
-            # This can make every event provide a smaller boost or make a few events stack a large boost
-            B:"JSON Spawner Bonus - Calls First Spawn"=false
-
-            # List of Lycanites Spawner Names to attempt to apply Player Mob Levels
-            S:"JSON Spawner Bonus - Spawner Names" <
-                chaos
-                disruption
-                sleep
-             >
-
-            # Inject handling for Player Mob Levels affecting the main Bosses
-            B:"Main Boss Bonus"=true
-
-            # Remove treat pacifying and lower reputation gain when taming high leveled creatures
-            B:"Over Leveled Penalty"=true
-
-            # Creature level to compare to PML highest pet entry level, set to 0 to disable
-            I:"Over Leveled Penalty - Start"=20
-
-            # Whether treat reputation will be penalized if creature is over leveled.
-            B:"Over Leveled Penalty - Treat Point Penalty"=false
-
-            # If creature could be tempted, will it remain able to be tempted if over leveled
-            B:"Over Leveled Penalty - Treat Tempt"=false
-
-            # Lycanites Pet Manager updates Player Mob Level Capability with pet entry information
-            B:"Pet Manager Tracks Pet Levels"=true
-
-            # Inject handling for Player Mob Level to affect summon staff minions
-            B:"Player Mob Level Summon Staff"=true
-
-            # Whether weakened soulbound inventory GUIs are unable to be accessed
-            B:"Soulbound Weakened Dimensions - Disable Inventory"=true
-
-            # Whether weakened soulbounds are unable to be mounted
-            B:"Soulbound Weakened Dimensions - Disable Mounting"=true
-
-            # Whether weakened dimensions prevent soulbound spirit recharge
-            B:"Soulbound Weakened Dimensions - Disable Spirit Recharge"=true
-
-            # Dimension IDs where soulbounds are level capped at Player Mob Level
-            I:"Soulbound Weakened Dimensions - IDs" <
-                111
-                3
-             >
-
-            # Whether weakened soulbounds can spawn in dimensions blacklisted by vanilla Lycanites.
-            # Lazy option that can be hot swapped in game.
-            B:"Soulbound Weakened Dimensions - Overrules Blacklist"=true
-
-            # Soulbound Weakened Dimensions is Whitelist
-            B:"Soulbound Weakened Dimensions - Whitelist"=true
-
-            # Inject handling for soulbounds to have limited Player Mob Level bonuses in specified dimensions.
-            # Prone to desyncs without 'Fix Client Pet Stat Desync'
-            # Will fail without 'Fix Properties Set After Stat Calculation'
-            B:"Soulbounds Weakened In Specific Dimensions"=true
         }
 
         ##########################################################################################################
@@ -846,6 +1051,9 @@ general {
             # Whether Astaroth Minions are teleported away on spawn. Else they will follow and teleport with Asmodeus.
             B:"Astaroths Teleport Adjacent Node"=false
 
+            # Damage multiplier the attack does to non-players. Default Lycanites is 10, or 10x damage.
+            D:"Devil Gatling Pet Damage Modifier"=10.0
+
             # Whether on hit purge removes more than Lycanites defined list
             B:"Devil Gatling Purge Any Buff"=true
 
@@ -874,8 +1082,9 @@ general {
             B:"Disable Ranged Hitscan"=true
 
             # Player detection range where if there are no players nearby, start healing. (Lycanites uses 64)
-            # LycanitesTweaks uses 96, which covers the entire arena if Asmodeus is in the center.
-            I:"Heal Portion - Range"=96
+            # 96 will cover the entire arena if Asmodeus is in the center.
+            # LycanitesTweaks uses 48, which is within Asmodeus' aggro range.
+            I:"Heal Portion - Range"=48
 
             # Replace the 50hp/sec heal with a 2% Max HP/sec heal
             B:"Heal Portion When No Nearby Players"=true
@@ -1150,183 +1359,6 @@ general {
         }
 
         ##########################################################################################################
-        # tweak creature stats
-        #--------------------------------------------------------------------------------------------------------#
-        # Various options to balance stats and debuff.
-        # Additional modifiers for Bosses, such as summoning level matching minions and nbt SpawnedAsBoss tag providing Rare Variant Stats.
-        # LycanitesTweaks caps speed/piercing and certain debuffs as high values don't provide a fair experience.
-        # Boss modifiers address high health bonuses + Boss Damage Limit being not fun.
-        ##########################################################################################################
-
-        "tweak creature stats" {
-            # Dependency for usings caps on bonus stats per level. Does not affect variant/NBT bonuses.
-            B:"0. Cap Specific Stats"=true
-
-            # Ratio of max bonus defense, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Defense Ratio"=4.0
-
-            # Ratio of max bonus effect duration, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Effect Duration Ratio"=5.0
-
-            # Ratio of max bonus movement speed, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Movement Speed Ratio"=3.0
-
-            # Ratio of max bonus pierce, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Pierce Ratio"=3.0
-
-            # List of elements that are blacklisted from applying their buffs. In vanilla Lycanites, Wisps are the only mobs who apply buffs.
-            # Soulgazers providing buffs when used on tamed pets check this.
-            # Buffs that have no functions and textures should be blacklisted.
-            # Format: [elementName]
-            S:"0.b Elements' Buffs - Blacklisted Elements" <
-                frost
-                lava
-                lightning
-                poison
-                arcane
-                fae
-                order
-             >
-
-            # List of elements whose Buffs will have capped level scaling. In vanilla Lycanites, Wisps are the only mobs who apply buffs.
-            # Soulgazers providing buffs when used on tamed pets check this.
-            # Format: [elementName, maxScaleLevel]
-            # 	elementName - Name of the element to limit, must be all lowercase
-            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
-            S:"0.b Elements' Buffs Level Limit" <
-                arbour, 15
-                earth, 15
-             >
-
-            # List of elements whose Debuffs will have capped level scaling.
-            # Format:[elementName, maxScaleLevel]
-            # 	elementName - Name of the element to limit, must be all lowercase
-            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
-            S:"0.b Elements' Debuffs Level Limit" <
-                arcane, 15
-                chaos, 15
-                lightning, 15
-                phase, 15
-             >
-
-            # List of various Lycanites that apply effects and toggle-able level scaling cap.
-            # Format:[thing, maxScaleLevel, enable]
-            # 	thing - Do not change from defaults
-            # 	maxScaleLevel - Final Level before duration and amplifier stop increasing
-            # 	enable - 'true' Will use the level limit
-            S:"0.b Misc Effects Level Limit" <
-                barghest, 15, false
-                cockatrice, 15, true
-                eechetik, 15, false
-                quetzodracl, 15, false
-                raiko, 15, false
-                shade, 15, true
-                strider, 15, false
-                warg, 15, true
-                EffectAuraGoal, 15, true
-             >
-
-            # Dependency for toggles. Only affects per level bonus, does not modify variant or nbt bonuses.
-            B:"1. Swap Health & Damage Per Level Bonus"=true
-
-            # Any Hostile Minions, such as those of the main bosses and rare variants
-            B:"1.a Hostile Minions"=true
-
-            # Rahovart, Asmodeus, and Amalgalich
-            B:"1.a Main Bosses"=true
-
-            # Anything tagged with SpawnedAsBoss such as Dungeon Bosses
-            B:"1.a Tagged Boss"=true
-
-            # Any Tamed Mobs. Intended for all players' mobs to feel more impactful but still trade 1 for 1.
-            B:"1.a Tamed Mobs"=true
-
-            # Dependency for modifying. Only affects per level bonus, does not modify variant or nbt bonuses.
-            B:"2. Modify Total Boss Health Per Level Bonus"=true
-
-            # Rahovart, Asmodeus, and Amalgalich. Intended to balance the Boss Damage Limit.
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"2.a Main Boss Total Ratio"=0.5
-
-            # Anything tagged with SpawnedAsBoss such as Dungeon Bosses. Intended to balance when the Boss Damage Limit is applied.
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"2.a Tagged Boss Excluding Rare Total Ratio"=0.5
-
-            # Intended when Dungeon Bosses only have the Boss Damage Limit when Rare.
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"2.a Tagged Boss Exclusively Rare Total Ratio"=0.5
-
-            # Whether Altar Mini Bosses should be tagged with the SpawnedAsBoss NBT to interact with LycanitesTweaks features.
-            # Unlike Dungeon Bosses, this tag is not used for correcting boss stat balance and is mostly used for Loot Table checks.
-            B:"Altar Mini Boss SpawnedAsBoss NBT Tag"=true
-
-            # Rahovart/Asmodeus mechanic based minions match the boss' levels
-            B:"Minion Level Matches Host - Boss Mechanics"=true
-
-            # Summon minion goal matches levels (AI Goal/Most Mobs). Amalgalich minions use this.
-            B:"Minion Level Matches Host - Entity Summon Goal"=true
-
-            # Lazy option to force dungeon configs to follow the Rare variant stat rebalancing.
-            # This will IGNORE dungeon configs and logs anytime it does so.
-            # It is recommended to set "loadDefault" to "true" or change manually.
-            # Default Lycanites distributes Bosses between level 10-250. This will result in 10 levels per config dungeonLevel, between 20-50
-            B:"Override Dungeon Boss Config Level"=false
-
-            # Option to allow SpawnedAsBoss tagged mobs to naturally spawn, intended to simulate the random Rare Variant experience for every mob.
-            # Min: 0.0
-            # Max: 1.0
-            D:"Spawned As Boss Tagged Natural Spawns - Chance"=0.0044999998062849045
-
-            # Try to store naturally spawned SpawnedAsBoss entities in an Encounter Crystal.
-            # Used as a way to both hide the boss bar and indicate a Boss entity.
-            B:"Spawned As Boss Tagged Natural Spawns - Encounter Crystal"=true
-
-            # Sever side control of whether red boss bars should be hidden for non persistent SpawnedAsBoss mobs.
-            # This is similar to the vanilla Lycanites option to hide Rare Variant green boss bars.
-            B:"Spawned As Boss Tagged Natural Spawns - Hide Boss Bar"=false
-
-            # Server side count of the langkey "creature.spawnedasboss.prefix.n", which is used to add a prefix to boss names.
-            # Min: 0
-            # Max: 2147483647
-            I:"Spawned As Boss Tagged Natural Spawns - Random Names"=8
-
-            # Grant all lycanites tagged as SpawnedAsBoss the Boss Damage Limit mechanic.
-            # This is part of providing consistency across Dungeon Bosses as only Rare Variants had this mechanic.
-            # Vanilla Lycanites does not use this tag outside of Dungeons.
-            # There are some cases where this is intentionally overridden, such Enhanced Asmodeus' Astaroths
-            B:"Spawned As Boss Tagged Uses Boss Damage Limit"=true
-
-            # Grant all lycanites tagged as SpawnedAsBoss the Rare variant stat multipliers instead of the Common/Uncommon.
-            # This will automatically attempt to rebalance Dungeon Bosses that try to load default configs.
-            # Default Lycanites distributes Bosses between level 10-250. This will result in 10 levels per config dungeonLevel, between 20-50.
-            # This will also enable non persistent peaceful category (Chupa and Pinky) SpawnedAsBoss mobs to despawn naturally.
-            B:"Spawned As Boss Tagged Uses Rare Stats"=true
-
-            # Any mob summoned via staff or pedestal. Used as a reward for rank 2 knowledge with the imperfect summoning rework.
-            B:"Stat Bonus Receivers - Player Summoned Minions"=true
-
-            # Any mob given a Soulstone or from one
-            B:"Stat Bonus Receivers - Soulbounded Pets"=true
-
-            # Any mob tamed with treats
-            B:"Stat Bonus Receivers - Tamed With Treats"=true
-
-            # Dependency for toggles. Vanilla Lycanites erroneously allowed Soulbounds via oversight.
-            B:"Variant/NBT Stat Bonus Receivers"=true
-        }
-
-        ##########################################################################################################
         # vanilla lycanites item tweaks
         #--------------------------------------------------------------------------------------------------------#
         # Tweaks to the vanilla Lycanites items, generally preparing them for integration with other mods, namely RLCombat and So Many Enchantments.
@@ -1335,15 +1367,13 @@ general {
         ##########################################################################################################
 
         "vanilla lycanites item tweaks" {
-            # Allows Lycanites Equipment to be enchanted.
-            # Allows all WEAPON enchantments except Sweeping Edge.
-            # Allows Efficiency as the only TOOL enchantment.
-            # Allows Unbreaking as the only BREAKABLE enchantment.
-            # Optional toggles to enable all TOOL and BREAKABLE are available as those require special handling.
+            # Allows Lycanites Equipment to be enchanted based on the parts used.
+            # Feature/Harvest Type -> Enchant Type
+            # damage -> weapon
+            # harvest -> tools
+            # axe/pickaxe/hoe/shovel -> So Many Enchantments Type
+            # Unbreaking is always allowed while Mending can be disabled via config.
             B:"Crafted Equipment Enchantments"=true
-
-            # Allows Lycanites Equipment to be enchanted with TOOL enchantments
-            B:"Crafted Equipment Enchantments - Allow TOOL Enchantments"=true
 
             # Minimum level all parts of equipment must be in order to enchant
             I:"Crafted Equipment Enchantments - Minimum Part Level"=3
@@ -1419,82 +1449,27 @@ general {
             B:"Soulgazer Soulbound Debuffs Immunities - Keybound Only"=true
 
             # Base EXP Required to level up, scales with level, Lycanites Charge EXP is 50
-            I:"Summon Staff - Base Levelup Experience"=500
-
-            # The first infused Charge is bound to the summon staff and limits the possible elements to use.
-            # Else every charge and every element can be leveled up on a single staff.
-            B:"Summon Staff - Elements Limited By Charge"=true
+            I:"Summon Staff - Base Levelup Experience"=100
 
             # Summon Staffs can use the Equipment Infuser in order to gain experience
             B:"Summon Staff Equipment Infuser"=true
 
             # Save and use NBT stored Element Level Map to spawn higher level minions
             B:"Summon Staff Level Map"=true
+
+            # Wraith Sigil copies variant and level from Rahovart to summon Wraiths with those properties
+            B:"Wraith Sigil Level Stats"=true
+
+            # Whether Wraiths should apply the debuffs of the "Voiding" element
+            B:"Wraith Sigil Level Stats - Apply Voided"=true
+
+            # Whether Wraiths should copy all the potion effects of the users.
+            B:"Wraith Sigil Level Stats - Copy Potions"=true
+
+            # Wraiths have 0.5 seconds to melee nearby targets. Lycanites default is 4.0 or 4x one melee hit.
+            D:"Wraith Sigil Level Stats - Melee Damage Scale"=4.0
         }
 
-    }
-
-    ##########################################################################################################
-    # minor features mixins
-    #--------------------------------------------------------------------------------------------------------#
-    # Mixins based Tweaks with very basic options
-    ##########################################################################################################
-
-    "minor features mixins" {
-        # Bleed damage uses setDamageIsAbsolute ontop of Magic=Armor ignoring, making it ignore Resistance and other potion effects that reduce damage, as well as Protection enchantments.
-        B:"Bleed Pierces"=true
-
-        # Move the Damage Limit DPS calc from attackEntityFrom to the slightly earlier LivingDamageEvent LOWEST, moving it to BEFORE death check.
-        # Required to properly limit the dealt dmg.
-        # Additionally limits damage amount on LivingDamageEvent LOWEST, this will fix one-shots dropping mob loot early.
-        B:"Boss DPS Limit Recalc"=true
-
-        # Set to true to kill associated minions and projectiles when a Lycanites Mobs boss entity dies
-        B:"Boss Death Kills Minions and Projectiles"=true
-
-        # Allows the visual tracking range for Boss Projectile and Portal Sprites to be modified.
-        # Rahovart's Hellfire Barriers are affected the most as ones on the other side of the arena did not render at all.
-        B:"Boss Projectile Modify Tracking Range"=true
-
-        # Lycanites uses 40
-        # Min: 40
-        # Max: 2147483647
-        I:"Boss Projectile Modify Tracking Range - Value"=80
-
-        # When reading familiars from URL, Set Spawning Active to false to not automatically spawn them on login
-        B:"Familiars Inactive On Join"=true
-
-        # Fix Iron Golems attacking tamed mobs
-        B:"Fix Golems Attacking Tamed Mobs (Vanilla)"=true
-
-        # Fix Withers attacking Tremors
-        B:"Fix Withers Attacking Tremors (Vanilla)"=true
-
-        # Enable customizable biome list for Arisaurs with the custom name Flowersaur. Flowersaurs have a custom texture that is unused in base LycanitesMobs
-        B:"Flowersaurs Naturally Spawn"=true
-
-        # List of biomes (modid:biomename) where custom name Arisaurs will spawn in
-        S:"Flowersaurs Naturally Spawn - Biomes" <
-            minecraft:mutated_forest
-            biomesoplenty:mystic_grove
-            twilightforest:enchanted_forest
-         >
-
-        # Fix explosion damage being reduced to 1 when going through lycanites fire (as if it was a full block). Also use vanilla's fire punch-out handling instead of treating the fire as a full block.
-        B:"Lycanites Fire Vanilla Like"=true
-
-        # Whether a Lycanite Mob should be considered undead when the Smited effect is active. This will for example allow the Smite enchant to work on them.
-        B:"Lycanites Smited Are Undead"=true
-
-        # Makes all vanilla Entities (and all modded Entities that don't have a specified Creature Attribute) an Undead creature while the Smited effect is active. This will for example allow the Smite enchant to work on them.
-        B:"Most Smited Are Undead (Vanilla)"=true
-
-        # Lycanites grants a +2 Explosion Power to explosions caused by Rare variants, increasing damage by around 3x.
-        # This will remove said bonus and no longer grant the large damage bonus as it is far above the intended Rare damage boost.
-        B:"Remove Projectile Explosion Radius Rare Bonus"=true
-
-        # Adds more parity to Repulsion and Weight, repulsion gains weights benefits. This will make Roas, Spectres and Threshers unable to pull an entity with repulsion, as well as disallowing picking up an entity with Repulsion (Behemophet/Fear)
-        B:"Repulsion Weight Benefits"=true
     }
 
     ##########################################################################################################
@@ -1505,6 +1480,13 @@ general {
     ##########################################################################################################
 
     "mod compatibility" {
+        # Mods such as RLMixins, Fermium Mixins, and Eagle Mixins contains copies of ones used in LycanitesTweaks.
+        # This toggle will disable them and Fermium Booter will log "mixin removal".
+        B:"0. Remove Duplicate Mixins"=true
+
+        # ClaimIt addon to cover some cases where specific area protection checks are needed, such as denying Altars in Claims.
+        B:"ClaimIt Compat (ClaimIt API)"=true
+
         # Makes Crafted Equipment reach stat influence ReachFix attack range
         B:"Crafted Equipment Bonus ReachFix Range (ReachFix)"=true
 
@@ -1533,11 +1515,14 @@ general {
         # Allows love arrows breeding to apply on Lycanites animals
         B:"Love Arrow Fix (Switch-Bow)"=true
 
-        # Fix Potion Core forcibly overwriting BaseCreatureEntity motionY 
+        # Fix Potion Core forcibly overwriting BaseCreatureEntity motionY
         B:"Potion Core Jump Fix (Potion Core)"=true
 
         # Whether to affect all mobs - otherwise only LycanitesMobs entities are affected
         B:"Potion Core Jump Fix - All Mobs"=true
+
+        # Repulsion nullifies the pulling effects of Arachnida and Seizer
+        B:"Repulsion Affects Abilities (Scape and Run Parasites)"=true
 
         # Allows Soulgazers to be worn as a bauble. Includes keybinds to enable auto/right clicks.
         B:"Soulgazer Bauble (BaublesAPI)"=true
@@ -1547,6 +1532,187 @@ general {
 
         # Sets Ender Pearls as the repair material
         B:"Soulgazer Bauble Ender Pearl Reforge"=true
+    }
+
+    ##########################################################################################################
+    # client options
+    #--------------------------------------------------------------------------------------------------------#
+    # Client-Side Options
+    ##########################################################################################################
+
+    "client options" {
+        # Logging for information that is automatic but not available every tick
+        B:"Debug Log Automatic Information"=false
+
+        # Logging for information that is manually triggered by players
+        B:"Debug Log Manual Trigger Information"=false
+
+        # Logging for information that can be dumped every tick
+        B:"Debug Log Tick Information"=false
+    }
+
+    ##########################################################################################################
+    # client mixins
+    #--------------------------------------------------------------------------------------------------------#
+    # Mixins based Client Tweaks
+    ##########################################################################################################
+
+    "client mixins" {
+        # Dependency for adding new/hiding Beastiary information. Required for server-side to know what Creature players have selected.
+        B:"0. Modify Beastiary Information"=true
+
+        # Adds a tab for Lycanites Altar renders and block counts
+        B:"0.a Lycanites Mobs Altar Beastiary Tab"=true
+
+        # Adds a tab to show Player Mob Levels information
+        B:"0.a LycanitesTweaks Player Mob Levels Beastiary Tab"=true
+
+        # Enables the ability for the Equipment Infuser and Station to display progress bars for additional items
+        # Ex. LycanitesTweaks Enchanted Soulkeys and Modified Summoning Staffs.
+        B:"1. Infuser and Station Display Additional Items"=true
+
+        # Case sensitive blacklist for hiding any Altar by name. Does not affect gameplay.
+        S:"Altar Display Blacklist" <
+         >
+
+        # Case sensitive blacklist for hiding any Creature by name. Does not affect gameplay.
+        # Used by Lycanites Tweaks to hide easter eggs.
+        S:"Creature Display Blacklist" <
+            sonofamalgalich
+         >
+
+        # Case sensitive blacklist for hiding any Creature Subspecies by name. Does not affect gameplay.
+        # Used by Lycanites Tweaks to hide easter eggs.
+        # 	Format: [creatureName: subspeciesIndex]
+        S:"Creature Subspecies Display Blacklist" <
+            darkling: 111
+         >
+
+        # Case sensitive blacklist for hiding any Element by name. Does not affect gameplay.
+        S:"Element Display Blacklist" <
+            nightmare
+            viral
+         >
+
+        # Adds stats on Summoning tab that shows Imperfect Summoning information
+        B:"LycanitesTweaks Imperfect Summoning Tab"=true
+
+        # Dependency for modifying how Equipment is rendered in 1st person.
+        # This will additionally mirror the render in offhand instead of having it copy the mainhand.
+        B:"Modify Equipment Rendering"=true
+
+        # Case sensitive blacklist for hiding Equipment Parts by type
+        S:"Modify Equipment Rendering - Parts To Skip" <
+            base_
+            head_
+            blade_
+            pike_
+            jewel_
+            axe_
+            pommel_
+         >
+
+        # Size Scale of Equipment
+        # Min: 0.0
+        # Max: 1.7976931348623157E308
+        D:"Modify Equipment Rendering - Size Scale"=1.0
+
+        # PML Beastiary Render order is determined by the order of this list.
+        # 	categoryName - Spelling must match 'Bonus Categories' entries else hidden
+        # This will be compared to the existence of 'Bonus Categories' entries in the PML config
+        S:"Player Mob Levels Category Display Order" <
+            AltarBossMain
+            AltarBossMini
+            DungeonBoss
+            SpawnerNatural
+            SpawnerTile
+            SpawnerTrigger_
+            EncounterEvent_
+            SoulboundTame_
+            SummonMinion
+            SummonMinionInstant
+         >
+
+        # Have long tooltips be shortened and require Shift to be held down in order to show the full description.
+        # Equipment Mob Parts - Hides weapon stats and simplifies to xp, element, and slots.
+        # Equipment - Hides individual mob parts, block harvest, and melee effects.
+        B:"Shorten/Expand Tooltips With Shift"=true
+
+        # Replace the denial of sleep message mentioning monsters nearby with one that directly mentions Insomnia.
+        # Langkey is: "tile.bed.lycanites.insomnia"
+        B:"Unique Insomnia Message"=true
+    }
+
+    ##########################################################################################################
+    # minor features mixins
+    #--------------------------------------------------------------------------------------------------------#
+    # Mixins based Tweaks with very basic options
+    ##########################################################################################################
+
+    "minor features mixins" {
+        # Bleed damage uses setDamageIsAbsolute ontop of Magic=Armor ignoring, making it ignore Resistance and other potion effects that reduce damage, as well as Protection enchantments.
+        B:"Bleed Pierces"=true
+
+        # When calculating Boss damage limits, add a maximum damage check to LivingDamageEvent LOWEST.
+        # This will fix one-shot exploits dropping mob loot early.
+        # Mob abilities will still calculate bonuses based on attackEntityFrom.
+        B:"Boss DPS Limit Recalc"=true
+
+        # Set to true to kill associated minions and projectiles when a Lycanites Mobs boss entity dies
+        B:"Boss Death Kills Minions and Projectiles"=true
+
+        # Allows the visual tracking range for Boss Projectile and Portal Sprites to be modified.
+        # Rahovart's Hellfire Barriers are affected the most as ones on the other side of the arena did not render at all.
+        B:"Boss Projectile Modify Tracking Range"=true
+
+        # Lycanites uses 40
+        # Min: 40
+        # Max: 2147483647
+        I:"Boss Projectile Modify Tracking Range - Value"=80
+
+        # Disable player tames from trying avoid an attacker when damaged to improve responsiveness and feel more controllable.
+        B:"Disable Tamed Avoid Target AI"=true
+
+        # When reading familiars from URL, Set Spawning Active to false to not automatically spawn them on login
+        B:"Familiars Inactive On Join"=true
+
+        # Enable customizable biome list for Arisaurs with the custom name Flowersaur. Flowersaurs have a custom texture that is unused in base LycanitesMobs
+        B:"Flowersaurs Naturally Spawn"=true
+
+        # List of biomes (modid:biomename) where custom name Arisaurs will spawn in
+        S:"Flowersaurs Naturally Spawn - Biomes" <
+            minecraft:mutated_forest
+            biomesoplenty:mystic_grove
+            twilightforest:enchanted_forest
+         >
+
+        # Fix explosion damage being reduced to 1 when going through lycanites fire (as if it was a full block). Also use vanilla's fire punch-out handling instead of treating the fire as a full block.
+        B:"Lycanites Fire Vanilla Like"=true
+
+        # The Lycanites "fixate target" property is not used in vanilla, however LycanitesTweaks uses it to have mini bosses focus on players.
+        # This modifies the behavior so mobs with this property can retaliate properly against other attackers.
+        B:"Lycanites Fixate Target Tweaks"=true
+
+        # Whether a Lycanite Mob should be considered undead when the Smited effect is active. This will for example allow the Smite enchant to work on them.
+        B:"Lycanites Smited Are Undead"=false
+
+        # Makes all vanilla Entities (and all modded Entities that don't have a specified Creature Attribute) an Undead creature while the Smited effect is active. This will for example allow the Smite enchant to work on them.
+        B:"Most Smited Are Undead (Vanilla)"=false
+
+        # Allows the PvP pet control to control if the pet can attack a boss entity.
+        # Lycanites reduces pet damage vs bosses by 75%, so it's not always preferable to attack a boss.
+        B:"PvP Sets Boss Targeting"=true
+
+        # Allows the PvP pet control to control if griefing abilities are enabled.
+        # Applies too: Beholder, Cacodemon, Troll, and Wraith
+        B:"PvP Sets Griefing"=true
+
+        # Lycanites grants a +2 Explosion Power to explosions caused by Rare variants, increasing damage by around 3x.
+        # This will remove said bonus and no longer grant the large damage bonus as it is far above the intended Rare damage boost.
+        B:"Remove Projectile Explosion Radius Rare Bonus"=true
+
+        # Adds more parity to Repulsion and Weight, repulsion gains weights benefits. This will make Roas, Spectres and Threshers unable to pull an entity with repulsion, as well as disallowing picking up an entity with Repulsion (Behemophet/Fear)
+        B:"Repulsion Weight Benefits"=true
     }
 
     ##########################################################################################################
@@ -1617,6 +1783,9 @@ general {
         # Fix divide by zero crash in FireProjectilesGoal and high RangedSpeed preventing attacks
         B:"Fix Creature Ranged Speed"=true
 
+        # Fix Ignibus and Serpix firing one of their projectiles with 10 times the intended offset
+        B:"Fix Entity Projectile Offset"=true
+
         # Fix Ettin checking for inverted griefing flag
         B:"Fix Ettin grief flag"=true
 
@@ -1626,11 +1795,19 @@ general {
         # Fix HealWhenNoPlayersGoal trigger check using AND instead of OR therefore bricking in most cases
         B:"Fix Heal Goal Check"=true
 
+        # Some Lycanites JSON configs have inconsistencies/missing functionalities that are expected.
+        # 	Allows "crop", "ore", and "tree" to use block whitelist/blacklist.
+        # 
+        B:"Fix Lycanites JSON Consistency"=true
+
         # Fix Lycanites Entities spawning their minions in walls. If collision is detected, spawn on top of host instead.
         B:"Fix Minions Spawning in Walls"=true
 
         # Have NV deny Blindness from applying. This fixes visual flashing when blindness is applied every tick
         B:"Fix Night Vision Curing Blindness"=true
+
+        # Fix Amalgalich and Archvile overhead projectiles being offset from the center of their target and missing.
+        B:"Fix Overhead Projectile Offset"=true
 
         # Fix Pickup host entity losing track of target such as when holding inside a wall
         B:"Fix Pickup Target"=true
@@ -1641,8 +1818,22 @@ general {
         # Fix Serpix Blizzard projectile spawning in the ground
         B:"Fix Serpix Blizzard Offset"=true
 
+        # Mounted Lycanites are not pushed around by other entities, however they will store velocity changes.
+        # This will fix damage and dismounting applying spontaneous velocity
+        B:"Fix Spontaneous Mounted Velocity"=true
+
+        # Most tamed Lycanites do not clear their blacklisted entity targets, this will allowed tamed mobs to attack any mob.
+        B:"Fix Tamed Entity Can Attack Target"=true
+
         # Players can only interact with Lyca crafting blocks from very low distances. This fix instead makes them copy the vanilla block (crafting table, furnace etc) behavior
         B:"Fix Tile Entity Interaction Distance"=true
+
+        # Fixes Withers attacking Tremors as the handling was broken. Additionally prevents Iron Golems from attacking tamed mobs.
+        B:"Fix canBeTargetedBy Handling"=true
+
+        # Lycanites Mobs intended invisibility to be super buffed, fully negating aggro except for mobs with true sight and night vision.
+        # This is disabled by default due to how powerful it is.
+        B:"Fix canBeTargetedBy Handling - Legacy Invisibility"=true
 
         # Fix Soulcubes not being instantly removed after the Boss Event starts.
         # The intent was that the arena builder would replace it, however the delay allows the Soulcube to be collected in various cases.
@@ -1668,6 +1859,11 @@ general {
 
         # Removes the floor/ceiling rounding with Rejuvenation and Decay. Rejuv will not have a minimum healing boost and Decay will not nullify low healing.
         B:"Remove Healing Rejuv/Decay Rounding"=true
+
+        # Some Lycanites entity properties are not synced to client, this will fix:
+        # * Random Rare Variant boss bars not being shown upon spawning.
+        # * The Extra Mob Behavior NBT never being reloaded to client after being set.
+        B:"Sync Missing Properties"=true
 
         # PlaceBlockGoal post LivingDestroyBlockEvent for every call to canPlaceBlock. This fixes griefing protected blocks.
         B:"Vespids Posts Forge Event"=true

--- a/overrides/config/qualitytools/Quailities/tools.json
+++ b/overrides/config/qualitytools/Quailities/tools.json
@@ -21,6 +21,9 @@
       },
       {
         "class": "ItemCustomWeapon"
+      },
+      {
+        "class": "ItemEquipment"
       }
     ],
     "blacklist": [


### PR DESCRIPTION
1.0.12 has been out for a week and I've been lazy due to Dregora.

---------- 
MANIFEST IS NOT UPDATED IN THIS PR - I've seen that you keep those changes separate from updating a mod's config.
----------

The main LycanitesTweaks config was regenerated and the order was changed leading to a massive diff comparison.

Config Additions:
* Allowed Lycanites Equipment to have tool Qualities (Reforged with prismarine crystals, the lycanites specified max repairing item)
* Made use of Vanilla Lycanites "Altar Stat Multiplier" configs and made them not as extreme

Major LycanitesTweaks Changes:
Added a reason to use Diamond/Emerald Soulkeys for Altar Minibosses that drop Soulstones
* These bosses spawn with across the board 2x stats
* Drops a one use 5 minute summon staff for the mini boss (weaker than natural mini bosses)
Rebalanced Charge Experience
* At level 50, swap to this basic log formula [BASE * (1 + ln(lvl) * 3.15), basically a smooth transition to log at level 50
* Enchanted Soulkey and Summoning Staff BASE experience requirement by 5x to match Pet BASE experience
* Reduced "Random Charge Level Scale" from 0.5 -> 0.1 
* Reduced the base Random Charge drop range to [1,1]
* Removed the looting bonus from Random Charge drops
* Previous balance was based on a large mismatch of Soulkey and Staff experience requirements compared to pets