### PR TITLE
Config for Lycantes Tweaks 1.0.16

### DIFF
--- a/overrides/config/lycanitestweaks.cfg
+++ b/overrides/config/lycanitestweaks.cfg
@@ -1,6 +1,16 @@
 # Configuration file
 
 general {
+    # Override the "loadDefault" field in Lycanites JSON Config
+    # 	READ_VALUE - Default behavior
+    # 	ALL_TRUE - Force reset all JSON configs
+    # 	ALL_FALSE - Skip resets, will skip all file writing
+    # Valid values:
+    # READ_VALUE
+    # ALL_TRUE
+    # ALL_FALSE
+    S:"Lycanites JSON Load Override"=READ_VALUE
+
     # LycanitesTweaks has features that rely on being loaded by Lycanites Mobs.
     # Makes Lycanites Mobs check and load JSON resources from LycanitesTweaks.
     # JSONs modifications include default config rebalancing and custom additions.
@@ -63,15 +73,50 @@ general {
 
             # What level the slower growing log calc starts getting used. Set to 0 to disable and only use the vanilla calc.
             I:"Experience Calculation - Log Start Level"=50
+
+            # Enable an EXP Share for Lycanites tames that is like one used in MOBAs.
+            # 	When kill XP drops, check around the killed target and credited player.
+            # 	A pool based on the XP Value dropped is split among valid tames.
+            # 	+1 XP is the minimum granted to valid tames.
+            B:"Vanilla Kill Experience"=true
+
+            # The player is counted and will reduce the XP distributed to tames.
+            # 	20 XP for 1 Tame -> 20 XP for each tamed
+            # 	20 XP for 1 Tame + 1 Player -> 10 XP
+            # 	20 XP for 4 Tame -> 5 XP
+            # 	20 XP for 4 Tame + 1 Player -> 4 XP
+            B:"Vanilla Kill Experience - Factor Player"=true
+
+            # Range in blocks from the kill target or player for a tame to receive kill XP
+            # Min: 0.0
+            # Max: 32.0
+            D:"Vanilla Kill Experience - Range"=8.0
+
+            # The XP value dropped for the player will be reduced by 1/n, where n is the counted tames.
+            B:"Vanilla Kill Experience - Reduce Player XP"=true
+
+            # The Soulgazer will be required in order for the EXP Share to be active.
+            B:"Vanilla Kill Experience - Require Soulgazer"=true
+
+            # Soulbound tames will be valid XP receivers, else only non soulbound pets will benefit
+            B:"Vanilla Kill Experience - Soulbound"=true
+
+            # A multiplier on the XP Value Total that can be used to reduce or increase distributed XP
+            # Min: 0.0
+            # Max: 1.7976931348623157E308
+            D:"Vanilla Kill Experience - Value Modifier"=1.0
         }
 
         ##########################################################################################################
         # custom staffs
         #--------------------------------------------------------------------------------------------------------#
+        # Items provided by LycanitesTweaks
+        # 	Fantastical Feast - Held passive/bauble that increase eating/drink speed.
+        # 	Vile Matter - Held passive/bauble debuff self+aura based on beastiary creature selection.
         # Various staffs based on the current Summon Staffs and the older Scepters.
-        # Charge Staff - Essentially a bow that shoots Lycanites charges.
-        # Challenge Soul Staff - Dropped from Altar bosses, summons them as a temporary minion.
-        # Eventful Staff - Seasonal drop, basic Summoning Staff that always summons a specific minion.
+        # 	Charge Staff - Essentially a bow that shoots Lycanites charges.
+        # 	Challenge Soul Staff - Dropped from Altar bosses, summons them as a temporary minion.
+        # 	Eventful Staff - Seasonal drop, basic Summoning Staff that always summons a specific minion.
         ##########################################################################################################
 
         "custom staffs" {
@@ -100,29 +145,102 @@ general {
             # Format: [modid: path]
             S:"Charge Staff Enchantments Blacklist" <
                 minecraft:infinity
-                minecraft:flame
-                minecraft:punch
                 mujmajnkraftsbettersurvival:arrowrecovery
                 mujmajnkraftsbettersurvival:blast
                 mujmajnkraftsbettersurvival:multishot
-                somanyenchantments:lesserflame
-                somanyenchantments:advancedflame
-                somanyenchantments:supremeflame
-                somanyenchantments:advancedpunch
-                somanyenchantments:rune_arrowpiercing
                 somanyenchantments:splitshot
              >
 
-            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
-            # This toggle controls whether these arrows can persist to apply effects that charge projectiles are unable to copy, such as knockback properties.
-            B:"Charge Staffs Arrows"=false
-
-            # Charge Staffs momentarily spawn in an arrow so that other mods may modify it in order to apply bonuses to charge projectiles.
-            # This toggle controls whether these arrows teleport every tick to the charge the arrow is linked to.
-            B:"Charge Staffs Arrows Follow Charge"=false
-
             # Whether Charge Staffs can have enchantments
             B:"Charge Staffs Enchantability"=true
+
+            # Some LycanitesTweaks items have configured Vanilla Equipment Slots and Bauble Types
+            # 	EquipmentSlot - [mainhand, offhand, feet, legs, chest, head]
+            # 		A empty entry specifies NULL
+            # 	BaubleType - [0, 1, 2, 3, 4, 5, 6]
+            # 		Negative values indicate no bauble slot Attributes from Custom Item Stats
+            # 		0 - Amulet
+            # 		1 - Ring
+            # 		2 - Belt
+            # 		3 - Trinket
+            # 		4 - Head
+            # 		5 - Body
+            # 		6 - Charm
+            # 	BaubleLimit - Number of duplicates allowed, set to 0 to disable equipping
+            # Equipment Slot species the slot that Item Stats will be provided as Attributes if possible
+            S:"Custom Item Slots" <
+                lycanitestweaks:hellshield, EquipmentSlot:offhand, BaubleType: 3, BaubleLimit: 1
+                lycanitestweaks:devilgatlinggun, EquipmentSlot:mainhand, BaubleType: 3, BaubleLimit: 1
+                lycanitestweaks:hellfirecannon, EquipmentSlot:mainhand, BaubleType: 3, BaubleLimit: 1
+                lycanitestweaks:fantasticalfeast, BaubleType: 3
+                lycanitestweaks:vilematter, BaubleType: 3
+             >
+
+            # Some LycanitesTweaks items use the Lycanites Creature Stats system
+            # 	health - The base health bonus
+            # 	defense - The base flat damage reduction
+            # 	armor - The base armor bonus
+            # 	speed - The base ground speed bonus
+            # 	damage - The base attack damage, 100% for melee 50% for projectiles
+            # 	attackSpeed - The base melee attack speed, hits per second
+            # 	rangedSpeed - The base item use speed, uses per second
+            # 	effect - Not used currently
+            # 	amplifier - Not used currently
+            # 	pierce - The base piercing damage amount
+            # Affected by item level
+            S:"Custom Item Stats" <
+                lycanitestweaks:hellshield, health: 1, defense: 4
+                lycanitestweaks:devilgatlinggun, damage: 4, pierce: 4, attackSpeed: 0.2, rangedSpeed: 2
+                lycanitestweaks:hellfirecannon, damage: 8, pierce: 8, attackSpeed: 0.2, rangedSpeed: 0.1
+             >
+
+            # The level bonus will be restricted by any creature stat caps set in the Creature Stats Config
+            B:"Custom Item Stats - Use Creature Stats Caps"=true
+
+            # Sets Golden Apples and Chorus Fruits as repair materials
+            B:"Fantastical Feast - Default Repair Items"=true
+
+            # Maximum Boost when holding a full stack.
+            D:"Feeding Frenzy - Eating and Drinking Boost"=3.0
+
+            # Adds and registers the Fantastical Feast, a passive held item/bauble that boosts Eating and Drinking speeds.
+            # 	Stackable consumable are provided a [Stack Count/Max Count] x BOOST% bonus
+            # 	[1/4], [1/16], and [1/64] provides the minimal boost
+            # 	[4/4], [16/16, and [64/64] provides the maximum boost
+            B:"Register Fantastical Feast"=true
+
+            # Adds and registers various items based on the main Lycanites bosses.
+            # 	Hellfire Cannon - Dropped by Rahovart. Charges a Hellfire Wave or Barrier attack
+            # 	Hellshield - Dropped by Asmodeus. Passively provides defence, can turn on a Life Link shield to split damage between Soulbounds
+            # 	Gatling Gun - Dropped by Asmodeus. Takes charges as ammo and shoots them
+            B:"Register Special Boss Drops"=true
+
+            # Load replacement creature JSON configs that directly adds the special drops.
+            B:"Register Special Boss Drops - JSON Replacements"=false
+
+            # Adds the special drops to the Vanilla Loot tables of the bosses
+            # Requires "Vanilla Lootables for Lycanites Mobs" to be enabled
+            B:"Register Special Boss Drops - Vanilla Loot Tables"=true
+
+            # Adds and registers the Vile Matter, a toggleable passive held item/bauble that provides a debuff aura user.
+            # 	When active, debuff the user, any debuffs on the user will be applied to nearby entities
+            # 	The debuffs are from any selected Beastiary creature which is summonable/tambeable and has Rank 2 Knowledge
+            B:"Register Vile Matter"=true
+
+            # Elemental Debuff duration, uses Lycanites Element Info config scaling/modifiers
+            I:"Vile Aura - Element Duration"=10
+
+            # A constant range for any user that is not a Player
+            D:"Vile Aura - Other User Range"=10.0
+
+            # A multiplier on the Player's Reach Attribute, the range will automatically adjust other mods changes
+            D:"Vile Aura - Player User Range"=2.0
+
+            # Tick Rate of the ability
+            I:"Vile Aura - Tick Rate"=20
+
+            # Sets any item in Lycanites's "Equipment Mana Items Medium" config as repair materials
+            B:"Vile Matter - Default Repair Items"=true
         }
 
         ##########################################################################################################
@@ -204,6 +322,13 @@ general {
             # 0.5 is 50% the mob's level, so +15 Enchantment Level for a lvl 30.
             #  + 0.1 is 10% the mob's level, so +5 Enchantment Level for a lvl 50.
             D:"SpawnedAsBoss Scaled With Levels Boss Level Scale"=1.5
+
+            # Lycanites Mob Part drop will use the Vanilla JSON loot tables instead of the Lycanites drop system.
+            B:"Vanilla Loot Tables Mob Parts"=true
+
+            # The value of the "looting_multiplier" field in the "random_chance_with_looting" Loot Condition.
+            # Default is 0.04, or +4% for each level of looting, which matches the bonus ratio for the Wither Skull drop from a Wither Skeleton.
+            D:"Vanilla Loot Tables Mob Parts - Looting Bonus"=0.03999999910593033
         }
 
         ##########################################################################################################
@@ -288,7 +413,7 @@ general {
             # Voided Max Health multiplied total to reduce (-0.1 means -10% health or being left over with 90% health)
             # Min: -1.0
             # Max: 0.0
-            D:"Voided Health Modifier"=-0.1
+            D:"Voided Health Modifier"=0.0
 
             # Voided applies item cooldown
             # Min: 0
@@ -521,25 +646,28 @@ general {
             # Dependency for usings caps on bonus stats per level. Does not affect variant/NBT bonuses.
             B:"0. Cap Specific Stats"=true
 
-            # Ratio of max bonus defense, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Defense Ratio"=4.0
 
-            # Ratio of max bonus effect duration, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Effect Duration Ratio"=5.0
-
-            # Ratio of max bonus movement speed, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Movement Speed Ratio"=3.0
-
-            # Ratio of max bonus pierce, set to 0 to disable the cap
-            # Min: 0.0
-            # Max: 1.7976931348623157E308
-            D:"0.a Pierce Ratio"=3.0
+            # Ratios of max bonus per stat
+            # Available Stats
+            # 	health
+            # 	defense
+            # 	armor
+            # 	speed
+            # 	damage
+            # 	attackSpeed
+            # 	rangedSpeed
+            # 	effectDuration
+            # 	effectAmplifier
+            # 	pierce
+            # 	sight
+            S:"0. Specific Stat Ratio Caps" <
+                defense, 4.0
+                speed, 3.0
+                attackSpeed, 3.0
+                rangedSpeed, 3.0
+                effect, 5.0
+                pierce, 3.0
+             >
 
             # List of elements that are blacklisted from applying their buffs. In vanilla Lycanites, Wisps are the only mobs who apply buffs.
             # Soulgazers providing buffs when used on tamed pets check this.
@@ -646,11 +774,31 @@ general {
             # This will also swap the Imperfect Summoning Minion stat penalty from reduced fire rate to reduced damage.
             B:"Apply Damage Attribute to Projectiles"=true
 
+            # Automatically scale the Boss DPS Limit with all Max Health changes
+            # 	For balance when certain mods use huge bonuses, such as Infernal Mob's common +100% cases
+            # Should not be used with "Boss DPS Limit Scale With Modifiers (Vanilla)" from the Integration Config
+            # Compared to the mentioned, this always scale no matter the source of Max HP changes.
+            B:"Boss DPS Limit Scale With Max HP"=true
+
             # Rahovart/Asmodeus mechanic based minions match the boss' levels
             B:"Minion Level Matches Host - Boss Mechanics"=true
 
             # Summon minion goal matches levels (AI Goal/Most Mobs). Amalgalich minions use this.
             B:"Minion Level Matches Host - Entity Summon Goal"=true
+
+
+            # Nerfs the infinite ceiling of certain abilities when used against Bosses.
+            # Abilities scale off the damage stat but do not check final damage dealt.
+            # The nerf will cap the scaling to the Boss Damage Limits.
+            # Affected:
+            # 	Chupacabra 50% damage stat to healing per attack
+            # 	Darkling 200% damage stat to healing per 2 seconds
+            # 	Ent 100% damage stat to healing per attack
+            # 	Shade effectAmplifier x 25% damage stat to healing per buff attack, normally disabled
+            # 	Shambler 50% damage stat to healing per attack
+            # 	Treant 100% damage stat to healing per attack
+            # 	Vorach 50% damage stat to healing per attack
+            B:"Nerf Melee Ability Infinite Ceiling"=false
 
             # Lazy option to force dungeon configs to follow the Rare variant stat rebalancing.
             # This will IGNORE dungeon configs and logs anytime it does so.
@@ -684,6 +832,14 @@ general {
             # Sever side control of whether red boss bars should be hidden for non persistent SpawnedAsBoss mobs.
             # This is similar to the vanilla Lycanites option to hide Rare Variant green boss bars.
             B:"Spawned As Boss Tagged Natural Spawns - Hide Boss Bar"=false
+
+            # Minimum Light Level condition using Lycanites builtin check
+            # 	-1 - Any Light Level
+            # 	0 - Light Level 0
+            # 	1 - Light Level 7
+            # 	2 - Light Level 14
+            # 	3 - Light Level 15
+            I:"Spawned As Boss Tagged Natural Spawns - Minimum Light Level"=1
 
             # Server side count of the langkey "creature.spawnedasboss.prefix.n", which is used to add a prefix to boss names.
             # Min: 0
@@ -722,6 +878,21 @@ general {
         ##########################################################################################################
 
         "creature interactions" {
+            # Applies Bow Enchantments to Charge Projectiles shot by Lycanites entities.
+            # The "Bow" must be in the mainhand.
+            # Has limited compatibility with other mods.
+            # Primarily intended for use with "Pets Have Full Set of Equipment" option.
+            B:"Apply Bow Enchantments to Charge Projectiles"=true
+
+            # Melee Handling to Charge Projectiles shot by Lycanites entities.
+            # Ranged Damage handling is changed to melee handing when holding an Enchanted Item
+            # Despite being conceptually odd, provides better compatibility with mods as ranged handling is less generic
+            # Primarily intended for use with "Pets Have Full Set of Equipment" option.
+            B:"Apply Melee Handling For Pet Projectiles"=true
+
+            # Breeding lycanites mobs will drop xp like vanilla animals.
+            B:"Breeding Drops Experience"=true
+
             # Allow removing latched Darklings with teleporting. Uses pickup mechanic distance checks, which is by default 32 blocks.
             B:"Darklings Drops With Distance"=true
 
@@ -952,6 +1123,9 @@ general {
             # Whether minion kill should heal a % of max hp instead of a flat amount. Lycanites uses a flat 25.0
             B:"Consumption Kill Heal Portion"=false
 
+            # If spawning is enabled, respawn time in ticks
+            I:"Crimson Epion Respawn Time"=600
+
             # Custom value for Shadow Fire extinguish width on death (Lycanites uses 10)
             I:"Epion Extinguish Width"=16
 
@@ -995,6 +1169,9 @@ general {
             # applies voided + 100% chance to remove one buff on contact,
             # and counts as a minion for Consumption kill healing. (JSON configurable!)
             S:"Lob Darklings Replacement Projectile Name"=lichlobdarklings
+
+            # If spawning is enabled, respawn time in ticks
+            I:"Lunar Grue Respawn Time"=600
 
             # Projectile to replace all players 'spectralbolt' auto attack. 
             # LycanitesTweaks replaces it with a projectile that noclips through terrain, 
@@ -1054,9 +1231,6 @@ general {
             # LycanitesTweaks uses a projectile that noclips through terrain and 
             # is meant to counter hiding being a pillar, requires Xray targeting to remember targets. (JSON configurable!)
             S:"All Players Auto Attack Projectile Name"=demonicchaosorb
-
-            # Whether Astaroth Minions use Rare/Boss Damage Limit
-            B:"Astaroths Boss Damage Limit"=false
 
             # Whether Astaroth Minions are flagged as SpawnedAsBoss, intended to interact with LycanitesTweaks SpawnedAsBoss Rare Stats feature.
             B:"Astaroths Boss SpawnedAsBoss Tag"=true
@@ -1119,8 +1293,8 @@ general {
             # Max: 2147483647
             I:"Hellshield Astaroths Phase 2 Summon Cap"=2
 
-            # Transitioning to Phase 2 will spawn the maximum cap of Astaroths instead of one (Vanilla Lycanites does this)
-            B:"Hellshield Astaroths Phase 2 Transition Summon All"=true
+            # Transitioning to Phase 2 will spawn this many Astaroths (Vanilla Lycanites spawns 2)
+            I:"Hellshield Astaroths Phase 2 Transition Summon Count"=2
 
             # Amount of Damage Reduction Hellshield provides. Lycanites uses 100%
             # Min: 0.0
@@ -1130,6 +1304,9 @@ general {
             # If minions have no target and are at least this distance away, teleport to host.
             # 40 allows minions to check behind pillars and still follow Asmodeus when at another node.
             I:"Minion Teleport Range"=40
+
+            # If spawning is enabled, respawn time in ticks
+            I:"Phosphorescent Chupacabra Respawn Time"=600
 
             # Whether Asmodeus targets players behind walls. This fixes the cheese strat of hiding behind a pillar.
             B:"Player Xray Target"=true
@@ -1144,8 +1321,8 @@ general {
             # Max: 2147483647
             I:"Rebuild Astaroths Phase 3 Summon Cap"=4
 
-            # Transitioning to Phase 3 will spawn the maximum cap of Astaroths instead of one (Vanilla Lycanites only summons one)
-            B:"Rebuild Astaroths Phase 3 Transition Summon All"=true
+            # Transitioning to Phase 3 will spawn this many Astaroths (Vanilla Lycanites spawns 1)
+            I:"Rebuild Astaroths Phase 3 Transition Summon Count"=2
 
             # HP healed per phase 3 Astaroth
             # Flat amounts can be any number while portions should be between 0.0 and 1.0
@@ -1177,6 +1354,9 @@ general {
         "enhanced rahovart" {
             # Main toggle to enable this feature and its configs
             B:"0. Enable Rahovart Modifications"=true
+
+            # If spawning is enabled, respawn time in ticks
+            I:"Ebon Cacodemon Respawn Time"=1200
 
             # Player detection range where if there are no players nearby, start healing. (Lycanites uses 64)
             # Setting to -1 will sync with the FindNearbyPlayersGoal, almost always 64 range.
@@ -1214,6 +1394,13 @@ general {
             # Whether all three of Rahovart Flame Wall attacks have their damage always match level 1 Rahovart. Rebalanced to focus on buff removal instead of damage.
             B:"Hellfire Energy Attacks Fixed Damage"=true
 
+            # The height scale based on Rahovart's height that determines the y position the orbs hover at
+            D:"Hellfire Energy Attacks Indicator Orb Height"=0.10000000149011612
+
+            # Render Scale of Hellfire Orbs that indicate where the next Hellfire Wall or Hellfire Barrier will spawn
+            # Set to 0 to disable the rendering
+            D:"Hellfire Energy Attacks Indicator Orb Size"=2.5
+
             # Knockback chance for Hellfire Energy Attacks. Lycanites uses 1.0 for 100%.
             # Knockback with these attacks generally causes juggling as it pushes players into the direction the attack is going.
             # LycanitesTweaks default is 0% to allow the choice to run through to take consistent damage at the cost of buff cleansing.
@@ -1223,7 +1410,7 @@ general {
             B:"Hellfire Energy Attacks Purge Any Buff"=true
 
             # Duration of Voided debuff in seconds, set to 0 to disable
-            I:"Hellfire Energy Attacks Voided Time"=3
+            I:"Hellfire Energy Attacks Voided Time"=1
 
             # How much Hellfire energy is gained from a Behemoth in Phase 2 (Lycanites uses 20 with 0 passive energy)
             # Min: 0
@@ -1239,14 +1426,14 @@ general {
             # Setting to -1 will not kill the minion.
             # Min: -1
             # Max: 100
-            I:"Hellfire Energy Main Minion Sacrifice Kill"=10
+            I:"Hellfire Energy Main Minion Sacrifice Kill"=5
 
             # How much Hellfire energy is gained from Rahovart friendly fire sacrificing a minion not specified in other configs.
             # Setting to -1 will not kill the minion.
             # In general this should apply to Wraith minions.
             # Min: -1
             # Max: 100
-            I:"Hellfire Energy Other Minion Sacrifice Kill"=5
+            I:"Hellfire Energy Other Minion Sacrifice Kill"=1
 
             # Hellfire energy passively gained per second in Phase 1 (Belph required to fire Wave)
             # Min: 0
@@ -1256,18 +1443,18 @@ general {
             # Hellfire energy passively gained per second in Phase 2 (Behemoth required for wall)
             # Min: 0
             # Max: 100
-            I:"Hellfire Energy Passive Phase 2"=3
+            I:"Hellfire Energy Passive Phase 2"=1
 
             # Hellfire energy passively gained per second in Phase 3 (Lycanites uses 5)
             # Min: 0
             # Max: 100
-            I:"Hellfire Energy Passive Phase 3"=6
+            I:"Hellfire Energy Passive Phase 3"=5
 
             # How much Hellfire energy is gained from Rahovart friendly fire sacrificing a rare/mini-boss minion.
             # Setting to -1 will not kill the minion.
             # Min: -1
             # Max: 100
-            I:"Hellfire Energy Rare Sacrifice Kill"=100
+            I:"Hellfire Energy Rare Sacrifice Kill"=50
 
             # How much Hellfire energy is refunded upon a p2->p3 transition per active wall
             # Min: 0
@@ -1321,6 +1508,9 @@ general {
 
             # Friendly damage instantly kills and contributes energy instead of requiring the minion to live for 20 seconds
             B:"Rahovart Friendly Fire Sacrifices Minion"=true
+
+            # If spawning is enabled, respawn time in ticks
+            I:"Royal Archvile Respawn Time"=1200
 
             # Should Phase 3 Summon an Ebon Cacodemon
             B:"Spawns Ebon Cacodemon"=true
@@ -1418,6 +1608,13 @@ general {
             # axe/pickaxe/hoe/shovel -> So Many Enchantments Type
             # Unbreaking is always allowed while Mending can be disabled via config.
             B:"Equipment Enchantments"=true
+
+            # Changes the "Too Expensive" limit when applying enchanted book to Equipment/Parts.
+            # An inclusive starting bound, if the cost is this number or higher, it will be too expensive
+            # Set to 0 to disable and use the Vanilla 40.
+            # Min: 0
+            # Max: 2147483647
+            I:"Equipment Enchantments - Anvil Cost Limit"=0
 
             # Multiplier on the cost in Levels to apply enchanted books through the Anvil
             D:"Equipment Enchantments - Anvil Cost Multiplier"=2.0
@@ -1548,6 +1745,10 @@ general {
         # This toggle will disable them and Fermium Booter will log "mixin removal".
         B:"0. Remove Duplicate Mixins"=true
 
+        # Integration to go along with the "Apply Bow Enchantments to Charges" Creature Interact option.
+        # Requires the mentioned Creature Interact config option to be enabled
+        B:"Apply SME Enchantments to Charge Projectiles (SoManyEnchantments)"=true
+
         # Adds "lycanitestweaks:bloodmoon" as a Spawner JSON type for Condition and Trigger fields.
         # The Condition can be used with any existing Spawner Trigger, checked after the trigger fires.
         #  + The Trigger functions like the "world" Trigger, except ticks during an active Bloodmoon.
@@ -1561,6 +1762,16 @@ general {
         # Additionally loads a spawner that is similar to "Darkness", but only active in the sky to discourage flying during a Bloodmoon.
         # This will ignore biome conditions and spawned mobs will NOT respect the Bloodmoon config for vanishing at Dawn, instead despawning after 5 minutes.
         B:"Bloodmoon Spawner JSON Rare Examples"=true
+
+        # Automatically scale the Boss DPS Limit with Op1 and Op2 Max Health Attribute Multipliers
+        # 	For balance when certain mods use huge bonuses, such as Infernal Mob's common +100% cases
+        # 	Max Health from levels will not affect the DPS Limit
+        # Should not be used together with "Boss DPS Limit Scale With Max HP" in the Creature Stats Config
+        # Compared to the mentioned, this will not apply to Max HP provided by Mob Levels
+        B:"Boss DPS Limit Scale With Modifiers (Vanilla)"=false
+
+        # The Butchering Enchantment will affect Lycanites animals
+        B:"Butchering Lycanites Animals (SoManyEnchantments)"=true
 
         # ClaimIt addon to cover some cases where specific area protection checks are needed, such as denying Altars in Claims.
         B:"ClaimIt Compat (ClaimIt API)"=true
@@ -1608,7 +1819,7 @@ general {
 
         # Whether applying Potion Core's True Shot Potion Effect will be swapped to Strength for Lycanites entities.
         # For balance when using the "Apply Damage Attribute to Projectiles" Creature Stats option.
-        B:"Potion Core Swap True Shot (Potion Core)"=false
+        B:"Potion Core Swap True Shot (Potion Core)"=true
 
         # Repulsion nullifies the pulling effects of Arachnida and Seizer
         B:"Repulsion Affects Abilities (Scape and Run Parasites)"=true
@@ -1699,6 +1910,70 @@ general {
             viral
          >
 
+        # Allows the vanilla Boss Bars to show additional properties related to the exact Boss.
+        B:"Lycanites Boss Info Overlay"=true
+
+        # Right side of the Boss Bar shows Icon and Health.
+        # Left side shows when the Consumption is winding up or active.
+        B:"Lycanites Boss Info Overlay - Amalgalich"=true
+
+        # Rendering controls for the position of the Event Art, if empty the render is disabled:
+        # 	Size Scale
+        # 	X Position
+        # 	Y Position
+        # 	Z Position
+        D:"Lycanites Boss Info Overlay - Amalgalich Event" <
+            0.25
+            -111.0
+            1.0
+            -50.0
+         >
+
+        # Right side of the Boss Bar shows Icon and Health.
+        # Left side shows when the Astaroth Hellshield or Healing is active.
+        B:"Lycanites Boss Info Overlay - Asmodeus"=true
+
+        # Rendering controls for the position of the Event Art, if empty the render is disabled:
+        # 	Size Scale
+        # 	X Position
+        # 	Y Position
+        # 	Z Position
+        D:"Lycanites Boss Info Overlay - Asmodeus Event" <
+            0.75
+            0.0
+            70.0
+            -50.0
+         >
+
+        # Enable various visual easter eggs.
+        # Vanilla Lycanites
+        # 	Experiment 69R - When Attacking
+        # RLCraft
+        # 	Kobold - When Damaged
+        # 	Krake - When Attacking
+        B:"Lycanites Boss Info Overlay - Easter Eggs"=true
+
+        # A basic display of Creature Icon and Health on the right side of the Boss Bar.
+        # 	Spawned As Boss - Red Color and an entity NBT property.
+        # 	Custom Name Boss - Green Color and must have a Custom Name set.
+        B:"Lycanites Boss Info Overlay - Other"=true
+
+        # Right side of the Boss Bar shows Icon and Health.
+        # Left side shows % of Hellfire Energy and current type of Hellfire Minions.
+        B:"Lycanites Boss Info Overlay - Rahovart"=true
+
+        # Rendering controls for the position of the Event Art, if empty the render is disabled:
+        # 	Size Scale
+        # 	X Position
+        # 	Y Position
+        # 	Z Position
+        D:"Lycanites Boss Info Overlay - Rahovart Event" <
+            -0.75
+            0.0
+            -80.0
+            -50.0
+         >
+
         # Adds stats on Summoning tab that shows Imperfect Summoning information
         B:"LycanitesTweaks Imperfect Summoning Tab"=true
 
@@ -1777,17 +2052,16 @@ general {
         # Bleed damage uses setDamageIsAbsolute ontop of Magic=Armor ignoring, making it ignore Resistance and other potion effects that reduce damage, as well as Protection enchantments.
         B:"Bleed Pierces"=true
 
-        # When calculating Boss damage limits, add a maximum damage check to LivingDamageEvent LOWEST.
-        # This will fix one-shot exploits dropping mob loot early.
-        # Mob abilities will still calculate bonuses based on attackEntityFrom.
+        # Move the calculations of the Boss DPS Limit to a later point in the order, After [LivingAttackEvent] -> After [LivingDamageEvent].
+        # 	Fixes one-shot exploits which drop mob loot early.
+        # 	Fixes other damage bonuses ignoring the limit and dealing additional damage.
         B:"Boss DPS Limit Recalc"=true
-
-        # Additionally calculates damageTakenThisSec based on LivingDamageEvent LOWEST instead of the earlier LivingAttackEvent.
-        # This prevents most other Forge Event damage bonuses from apply after the DPS cap is calculated.
-        B:"Boss DPS Limit Recalc - Reapply Limit"=true
 
         # Set to true to kill associated minions and projectiles when a Lycanites Mobs boss entity dies
         B:"Boss Death Kills Minions and Projectiles"=true
+
+        # Killing Boss Minions will directly mend armor. No XP Orb is dropped. Intended to encourage staying in Boss Arenas.
+        B:"Boss Minion Kills Provide Instant Mending"=true
 
         # Allows the visual tracking range for Boss Projectile and Portal Sprites to be modified.
         # Rahovart's Hellfire Barriers are affected the most as ones on the other side of the arena did not render at all.
@@ -1825,6 +2099,12 @@ general {
             twilightforest:enchanted_forest
          >
 
+        # Register Attributes and Handlers to replicate certain Attributes exclusive to Lycanites entities
+        # Defence - Flat damage reduction calculated after Armor and Protection
+        # Pierce - Flat damage as an additional attack that ignores Armor and Protection
+        # Ranged Speed - Not used as an attribute, treated as the rate specific items can be used
+        B:"Lycanites Creature Attributes For All Mobs"=true
+
         # Fix explosion damage being reduced to 1 when going through lycanites fire (as if it was a full block). Also use vanilla's fire punch-out handling instead of treating the fire as a full block.
         B:"Lycanites Fire Vanilla Like"=true
 
@@ -1850,7 +2130,7 @@ general {
         B:"Player Logout Saves Mob Event"=false
 
         # Multiplier on the remaining duration that will be saved.
-        D:"Player Logout Saves Mob Event - Remaining Duration"=0.5
+        D:"Player Logout Saves Mob Event - Remaining Duration"=0.1
 
         # Lycanites grants a +2 Explosion Power to explosions caused by Rare variants, increasing damage by around 3x.
         # This will remove said bonus and no longer grant the large damage bonus as it is far above the intended Rare damage boost.
@@ -1858,6 +2138,27 @@ general {
 
         # Adds more parity to Repulsion and Weight, repulsion gains weights benefits. This will make Roas, Spectres and Threshers unable to pull an entity with repulsion, as well as disallowing picking up an entity with Repulsion (Behemophet/Fear)
         B:"Repulsion Weight Benefits"=true
+
+        # Provides and option for Sky spawning using the vanilla spawner, however it requires more intrusive changes compared to "Water Monster Spawning"
+        # The "spawners" field in the Creature Config will parse for the following:
+        # 	monster - Will assign the creature to EnumCreatureType.MONSTER
+        # 	sky - Broadly matches all the varieties of sky json spawners
+        # The first entry with both in the Creature Config will check for an associated json for yMin and yMax checks
+        # "skyhighmonster" would check the skyhigh.json for example
+        # JSON configs must be manually changed
+        B:"Sky Monster Spawning"=false
+
+        # 1 in n chance to spawn. Should be set while mindful of the "Vanilla Replace Rate"
+        # Min: 1
+        # Max: 2147483647
+        I:"Sky Monster Spawning - Spawn Rate"=1
+
+        # 1 in n chance to replace the upper bound of the randomly chosen y position with the max world height.
+        # This will affect grounded spawning by providing many more (air) blocks to check.
+        # The vanilla spawner normally only selects the highest block for the upper bound.
+        # Min: 1
+        # Max: 2147483647
+        I:"Sky Monster Spawning - Vanilla Replace Rate"=3200
 
         # Adds the "watermonster" spawner type for JSON configs.
         # Functions exactly as the "monster" spawner type, however it also assigns spawning in Water Blocks.
@@ -1905,6 +2206,8 @@ general {
         # 	CreatureConfig -> "Elemental Fusion Mix Bonus"
         # The following are default misspellings that would need to be regenerated or manually corrected.
         # 	ItemConfig -> "prismarine_crystals" (Max Sharpness repair item)
+        # The following configs are incorrectly processed in-game and are fixed.
+        # 	"Disable Model Alpha" -> Removes an extra GlStateManager.disableBlend() call that can affect other visuals such as Potion Effects and Offhand Slot.
         B:"0. Fix Lycanites Config Errors"=true
 
         # Register Forge's fluid buckets for Lycanites fluids. Fixes dispensers not being able to pick up Lycanites fluids.
@@ -1927,7 +2230,10 @@ general {
         # Equipment post LivingDestroyBlockEvent for every block broken. This fixes custom structure cheeses.
         B:"Equipment Block Breaking Posts Forge Event"=true
 
-        # Fixes a bug where minions despawn and don't get properly cleared from boss mechanics
+        # Server side will send packets to update Amalgalich's Consumption animation when it changes state (start/end/client load)
+        B:"Fix Amalgalich/Force Goal Desyncs"=true
+
+        # Fixes a bug where minions despawn and don't get properly cleared from boss
         B:"Fix Asmodeus' Hellshield Minions"=true
 
         # Fix hostile AgeableCreature babies not dropping loot
@@ -1957,9 +2263,11 @@ general {
         B:"Fix Both Hands Performing Item Interactions"=true
 
         # Fix client side showing incorrect stats in the beastiary, interact gui, and other mods
+        # Additionally after server processes client side changes, send an update packet back to client
         B:"Fix Client Pet Stat Desync"=true
 
-        # All Lyc containers (Equipment Forges, Infuser, Station, Summoning Pedestal) have no Item Quick Move implementation (via shift clicking). This fix makes them use newer mc quick move mechanics where the crafting slots are preferred over the player inventory+hotbar.
+        # All Lyc containers (Equipment Forges, Infuser, Station, Summoning Pedestal) have no Item Quick Move implementation (via shift clicking).
+        # This fix makes them use newer mc quick move mechanics where the crafting slots are preferred over the player inventory+hotbar.
         # Also fixes a minimal bug in Lyca Pet chest inventory where one slot (bottom right in player inventory) was not reachable via quick move.
         B:"Fix Container Quick Move"=true
 
@@ -1984,11 +2292,13 @@ general {
 
         # Some Lycanites JSON configs have inconsistencies/missing functionalities that are expected.
         # 	Allows "crop", "ore", and "tree" to use block whitelist/blacklist.
-        # 
         B:"Fix Lycanites JSON Consistency"=true
 
         # Fix the Damage Source used by minions not copying properties of their original attack. Most apparent with ranged attacks not being set as projectiles.
         B:"Fix Minion Damage Source Properties"=true
+
+        # Fix Minions of mobs having their numerical ID saved instead of their UUID, causing reloading entities to almost always lose track of their minions.
+        B:"Fix Minion NBT List Saving"=true
 
         # Fix Lycanites Entities spawning their minions in walls. If collision is detected, spawn on top of host instead.
         B:"Fix Minions Spawning in Walls"=true
@@ -2022,24 +2332,38 @@ general {
         # Fix Pickup host entity losing track of target such as when holding inside a wall
         B:"Fix Pickup Target"=true
 
+        # Fix Projectiles checking Solid Block Material instead of the more accurate Block State check.
+        # Allows projectiles to hit targets within the fire or webs they place.
+        B:"Fix Projectile Non Solid Block Collision"=true
+
         # Fix properties, such as tamed state, being set after stat calculation. This fix adds a late additional recalculation.
         B:"Fix Properties Set After Stat Calculation"=true
+
+        # Fix Rahovart not saving Hellfire Barriers when unloaded
+        B:"Fix Rahovart Phase 3 Barrier Unloading"=true
 
         # Fix Serpix Blizzard projectile spawning in the ground
         B:"Fix Serpix Blizzard Offset"=true
 
         # Fix being able to use Soulstones on temporary minions, such as when enabling tameable and summonable creatures properties.
+        # Also makes breeding temporary minions also produce a child with the same limitations instead of being free to be Soulbound.
         B:"Fix Soulstone Use On Minions"=true
 
         # Mounted Lycanites are not pushed around by other entities, however they will store velocity changes.
         # This will fix damage and dismounting applying spontaneous velocity
         B:"Fix Spontaneous Mounted Velocity"=true
 
+        # Fix the Summoning Staff portal staying active if the Staff was swapped away from, swapping will perform the right click release.
+        B:"Fix Summoning Staff Swap Off Portal"=true
+
         # Most tamed Lycanites do not clear their blacklisted entity targets, this will allowed tamed mobs to attack any mob.
         B:"Fix Tamed Entity Can Attack Target"=true
 
         # Players can only interact with Lyca crafting blocks from very low distances. This fix instead makes them copy the vanilla block (crafting table, furnace etc) behavior
         B:"Fix Tile Entity Interaction Distance"=true
+
+        # Fix Hostile Wraith's charge ability selecting themselves as targets and instantly exploding.
+        B:"Fix Wraith Charge Instant Explode"=true
 
         # Fixes Withers attacking Tremors as the handling was broken. Additionally prevents Iron Golems from attacking tamed mobs.
         B:"Fix canBeTargetedBy Handling"=true
@@ -2079,10 +2403,62 @@ general {
         # Some Lycanites entity properties are not synced to client, this will fix:
         # * Random Rare Variant boss bars not being shown upon spawning.
         # * The Extra Mob Behavior NBT never being reloaded to client after being set.
+        # * A current health desync with Variants affecting HUD and Overlay mods.
         B:"Sync Missing Properties"=true
 
         # PlaceBlockGoal post LivingDestroyBlockEvent for every call to canPlaceBlock. This fixes griefing protected blocks.
         B:"Vespids Posts Forge Event"=true
+    }
+
+
+    ##########################################################################################################
+    # generic bestiary
+    #--------------------------------------------------------------------------------------------------------#
+    # Generic Bestiary within the Lycanites Beastiary
+    # Generates and loads JSON configs per mod/entity
+    ##########################################################################################################
+
+    "generic bestiary" {
+        # Skips the hard coded filtering that removes the bestiary entry of various modded entities
+        # Examples:
+        # 	Electroblob's Wizardry: Exclusively Summoned Mobs
+        # 	Ice and Fire: Placeable Mob Eggs, Placeable Mob Skulls, and Stone Statues
+        # 	Scape and Run Parasites: Indev Entities, Projectiles, Interactable Mob Gore
+        # Disable to skip this process and make their bestiary entries visible
+        B:"JSON Loading - Disable Certain Modded Entities"=true
+
+        # Skips the hard coded JSON writing of default Bestiary Modifications
+        # 	These are assigned automatically based on vanilla properties and behaviors
+        # Disable to skip this process and NOT write to JSONs
+        B:"JSON Loading - Disable Default Bestiary Modifications"=false
+
+        # Skips the hard coded filtering of default Bestiary Modifications from modded entities
+        # 	The filter helps when a vanilla behavior is override, such as Ice and Fire entity ages
+        # Disable to skip this process and write to JSONs regardless
+        B:"JSON Loading - Disable Default Modded Conflicts"=false
+
+        # The time in ticks it takes to be able to use a Soulgazer for knowledge again. Default is 200 (10 seconds).
+        # 	This is separate from the one used Lycanites entities
+        # Set to -1 to use the Lycanites entity value
+        B:"Max Knowledge Bonus"=true
+        D:"Max Knowledge Bonus - Boss Damage Reduction"=0.029999999329447746
+        D:"Max Knowledge Bonus - Non Boss Damage Reduction"=0.009999999776482582
+        B:"Max Knowledge Bonus - Soulgazer"=true
+
+        # Dependency for functionality: A Bestiary for everything non-Lycanites within the Lycanites Beastiary
+        # 	Functions similarly to the Lycanites Beastiary with Soulgazer usage and automatic knowledge gain.
+        # 	Automatic knowledge gain respects Lycanites config and uses Forge events to check breeding, taming, and killing.
+        # 	Every mod with entities will have a config in config/lycanitesmobs/!lycanitestweaks_ModInfos
+        # 	Every mod's entity will have a config in config/lycanitesmobs/!lycanitestweaks_GenericBestiaryEntities
+        # 	JSONs should match server and client to prevent desyncs
+        # 	Various clientside only JSON fields will not be generated/read on server
+        # Command [/lycanitestweaks beastiary]
+        B:"Mixin Toggle: Enable Generic Bestiary"=true
+
+        # The time in ticks it takes to be able to use a Soulgazer for knowledge again. Default is 200 (10 seconds).
+        # 	This is separate from the one used Lycanites entities
+        # Set to -1 to use the Lycanites entity value
+        I:"Soulgazer - Generic Study Cooldown"=200
     }
 
 }

--- a/overrides/config/lycanitestweaks.cfg
+++ b/overrides/config/lycanitestweaks.cfg
@@ -215,6 +215,17 @@ general {
             # 	Gatling Gun - Dropped by Asmodeus. Takes charges as ammo and shoots them
             B:"Register Special Boss Drops"=true
 
+            # Lycanite projectile names that can not be shot from the Gatling Gun
+            # Various behaviors are very laggy in large quantities
+            # 	Causing Explosion
+            # 	Spawning Mobs
+            # 	Spawning Projectiles
+            S:"Register Special Boss Drops - Gatling Ammo Blacklist" <
+                arcanelaserstorm
+                demonicblast
+                lobdarklings
+             >
+
             # Load replacement creature JSON configs that directly adds the special drops.
             B:"Register Special Boss Drops - JSON Replacements"=false
 

--- a/overrides/resources/srparasites/lang/en_us.lang
+++ b/overrides/resources/srparasites/lang/en_us.lang
@@ -5,3 +5,156 @@ tile.srparasites.evolutionlure_ten.name=Lure (§3Pure§f)
 
 # From Localizator
 message.srparasites.node_warning=Corruption Spreads
+
+# From SRP 1.10.6 for Lycanites Bestiary
+#INBORN
+lore.srparasites.buglin=§lEpithet:§r Lodo §l|§r §oRoughly the size of a basketball, this grub-like mass is formed from unstable flesh that bends and compresses in ways it should not, often appearing moments from rupturing. It carries a sharp metallic stench, and its substance tastes sour and aggressively acidic. Sixteen small hook-like claws, each about an inch long, line its underside and allow it to crawl across terrain or force itself into and out of living prey. It possesses no visible orifices, its body sealed like a malformed catalyst. Despite its flexibility, the Buglin is fragile under extreme pressure, rupturing instantly beneath the weight of an iron golem. Often found emerging from parasite tunnels.
+lore.srparasites.rupter=§lEpithet:§r Mudo §l|§r §oRupters operate in packs, using speed and numbers to split formations and harass isolated targets. When alone they are initially docile, though this behavior is subject to rapid change. Their musculature and tendons are folded into a dense, tesseract-like arrangement, while internal organs sprawl through the body like root systems with no clear structure. They weigh roughly the same as a cannonball and are capable of long, fast jumps, as well as climbing sheer surfaces, though they lack the dexterity to hang from ceilings that well. Tendrils twinge outward when agitated, gripping and boring into targets. Rupters frequently tear through cattle and smaller creatures, often killing them unintentionally. Solid matter is dissolved within the stomach and regurgitated back onto or into victims in small indistinguishable traces to efficiently transmit COTH without much retaliation. Their organs can be harvested, dried, and processed into a durable fiber-like material. Limbs may be torn free from the body similar to a spider; it remains unknown whether lost limbs can regenerate.
+lore.srparasites.mangler=§lEpithet:§r Nuuh §l|§r §oA close-quarters brute derived from Rupters, grown specifically for larger prey such as cattle, horses, and llamas. It weighs roughly the same as a large dog and is built for endurance and sustained force rather than speed. While bulkier in form, it retains the transmissible capabilities of its predecessors. The metallic scent present in Rupters is significantly stronger, often detectable before visual contact.
+lore.srparasites.carrier_flying=§lEpithet:§r Buthol §l|§r §oAn airborne infestation vector that hovers over active infestation zones. Three external bulbous growths hang blow the body, each containing a separate chemical component. When agitated, the compounds are forcibly mixed within the bulbs, causing rapid inflation before the body ruptures outward. Upon exposure to open air, the released mixture converts into a highly toxic, gas-like substance. The creature emits an odor similar to industrial chemical waste. Its surface is lined with fine hypodermic pricks and needle-like protrusions that damage nearby matter during detonation. The resulting compound rapidly melts exposed skin. Fire engulfment appears to destabilize and partially defuse the reaction.
+lore.srparasites.carrier_heavy=§lEpithet:§r Rathol §l|§r §oA heavy carrier designed to spread dense payloads of filth, toxins, and supporting parasites. The body is fully sealed, displaying no visible orifices, and functions primarily as a pressure vessel for stored noxious gas. Specimens may form empty of living mass yet remain filled with volatile chemical mixtures. Within its compartmental structure, several partially digested parasites remain suspended and mobile, swimming through the slurry. Prior to detonation, the organism dissolves its own internal organs and structural barriers, rapidly building internal pressure before rupturing. It reacts strongly to vibrations and emits an odor comparable to spoiled cooked meat sealed in a warm container. Fire engulfment appears to destabilize and partially defuse the reaction.
+lore.srparasites.carrier_light=§lEpithet:§r Gothol §l|§r §oA nimble carrier adapted for rapid strikes and short-range seeding. Its body is composed of hundreds of small compartments filled with a volatile slurry chemically bound to its vital functions. Internal organs are densely centralized, forming a firm core similar in structure to the center of a blackberry. Despite its instability, the organism is capable of maintaining balance independently and reacts aggressively to vibrations in its surroundings. It emits an odor comparable to spoiled cooked meat sealed in a warm container. Detonation leaves widespread residue. Fire engulfment appears to destabilize and partially defuse the reaction.
+lore.srparasites.gnat=§lEpithet:§r Ata §l|§r §oA small parasitic that uses its tentacles as rotating drill-heads to bore into hosts, allowing it to hijack and control both organic and inorganic entities. Individually weak, its appendages are exceptionally sharp and capable of chewing through dense material and resilient prey. A bulbous growth along its back dissolves or violently ruptures once embedded within a host, accelerating internal damage and takeover. It is heavily attracted to the scent of blood, to the point where it can be deliberately used as a distraction. The organism lacks any form of hearing and relies entirely on scent to navigate. Specimens are often coated in a slick, lubricant-like mucus, a residue from being secreted out of vermin.
+lore.srparasites.lice=§lEpithet:§r Viin §l|§r §oA highly erratic parasitic that uses its tentacles as rotating drill-heads to burrow into hosts, hijacking and controlling both organic and inorganic entities. Its abdomen is grossly inflated and lined with multiple bulbous growths that serve as both fuel and explosive charges, allowing it to force attachment and penetrate resistant targets. Movement is unpredictable to the point of inefficiency, making it difficult to track or swat. The organism is strongly attracted to the scent of sweat and blood and produces a faint humming noise when in close proximity.
+
+#ASSIMILATED
+lore.srparasites.sim_adventurer=§lEpithet:§r Sim §l|§r §oObserved traveling in loose groups, but once enough gather, they begin to match pace. They still check containers, doorways, and camp-like structures, as if memory survives in fragments. Occasionally, one will stop and stare into familiar spaces for several seconds, as though trying to remember what it once was. They appear to like assimilated dogs. I guess some things never change.
+lore.srparasites.sim_bear=§lEpithet:§r Sim §l|§r §oIts body has been preserved for force rather than speed. Specimens do not posture or bluff-charge like healthy bears; once agitated, they commit fully. Trees, barricades, and even damaged walls are treated as inconveniences by this thing. I observed one of them chewing the flesh from its own body once, as if to satiate an itch.
+lore.srparasites.sim_bigspider=§lEpithet:§r Dorpa §l|§r §oThis one produces excessive webbing mixed with foul organic runoff. Trails left behind often remain contaminated long after the host has passed. Its movements are strangely deliberate, as if it is less interested in pursuit and more concerned with spreading material across as much ground as possible. This one has a discernible temper, and I once witnessed it relentlessly stab holes into a pig with its legs, like a horse trampling a mound of flesh. I can only assume it did this because the prey was loud; it did not bother infesting it. Perhaps it was just food for fodder parasites?
+lore.srparasites.sim_cow=§lEpithet:§r Sim §l|§r §oStill reacts to the presence of feed and familiar sounds from husbandry, though only briefly. Once engaged, it lowers its head and drives forward with enough force to crush fencing or break bone. The contrast between its farm-bred mannerisms and sudden violence is deeply unsettling. It keeps wailing and crying whenever the sun rises. I don't know why.
+lore.srparasites.sim_dragone=§lEpithet:§r Sim §l|§r §oFlight appears difficult for its body, suggesting severe anatomical compromise. Even so, it remains highly lethal during descent and close approach. It seems to compensate for its failing body with distance and flight. Armor recovered from corpses often shows tearing and melted patterns, consistent with dipping tin foil in acid rather than clean predation. It does not seem acclimated to its body yet, as evidenced by it repeatedly thrashing its skull against the obsidian pillars of the End like a mace.
+lore.srparasites.sim_enderman=§lEpithet:§r Sim §l|§r §oDisplays unstable teleportation behavior and little concern for its own condition. When set ablaze, it does not retreat as expected and may instead continue advancing, igniting anything nearby in the process. It shows no sign of preserving itself and will throw itself into water despite its seemingly toxic nature. This suggests pain response has either been dulled or rendered irrelevant. Its beheaded variant doesn't seem to be affected by water for some reason, though.
+lore.srparasites.sim_horse=§lEpithet:§r Sim §l|§r §oThe abdomen is swollen with pressurized putrid matter, making even minor trauma hazardous. It startles easily under force, heat, or sudden rupture and may detonate before full collapse. Despite this instability, it can still close distance quickly. I've seen it thrash and cry like a living horse moments before detonation.
+lore.srparasites.sim_human=§lEpithet:§r Sim §l|§r §oRetains more recognizable behavior than most infected stock. Some specimens hesitate at doorways, look toward voices, or recoil from sudden heat before resuming attack. These reactions imply awareness has not been fully erased. They are difficult to study for long, as their movements often resemble panic as much as hostility. I can't discern what emotions they might be exhibiting.
+lore.srparasites.sim_pig=§lEpithet:§r Sim §l|§r §oAt a distance, it can still pass for an ordinary animal, especially when idle. Closer observation reveals constant chewing motions and abrupt changes in focus. It roots through organic waste, remains, and contaminated growth with equal interest. Very little of the original temperament appears intact, other than its impressive intelligence. I've seen it mindlessly roll around in the dirt and dig up carrots, but they just fall out of its maw, seemingly unwilling to commit to fully consuming them.
+lore.srparasites.sim_sheep=§lEpithet:§r Sim §l|§r §oIts crying is among the worst sounds recorded from infected livestock. The vocalization resembles an ordinary bleat, but prolonged listening reveals a strained, wet quality unlike anything natural. Nearby specimens sometimes grow more active when it cries. Whether this is communication or simple agitation is still unknown. I've noticed they can be dyed in a few select colors. Why anyone would want to do that, I don't know.
+lore.srparasites.sim_squid=§lEpithet:§r Sim §l|§r §oMoves through water with an almost passive grace, shedding rot, debris, and infectious matter as it drifts. Areas it frequents become visibly fouled over time. It shows little urgency when approached. The surrounding current often carries pieces of it farther than the body travels. I can't tell which end is its mouth. Maybe it has two.
+lore.srparasites.sim_villager=§lEpithet:§r Sim §l|§r §oStill turns its head toward movement with the same curious rhythm seen in normal villagers. Some have been observed lingering near doors, workstations, and former gathering places. The resemblance ends the moment one closes distance. Whatever social instinct remains has been hollowed out and repurposed into a grotesque imitation. I've seen one that did not approach in open aggression, though it looked nothing like a villager. Six legs, long hair, and an odd 'face'. Something tall and pulsing runs along the back of its neck. I once watched it place something strange into the hands of another thing nearby, as though carrying out some sort of exchange. I feel like it's trying to say something, but I can't make sense of its hollow noises. Not yet, anyway.
+lore.srparasites.sim_wolf=§lEpithet:§r Sim §l|§r §oResponds quickly to movement and rarely attacks without testing distance first. Multiple specimens will begin circling behavior even when no clear pack leader is present, implying the old instinct survives in broken form. Maybe it's chasing its own tail? Bites are fast, repetitive, and often aimed low, toward ankles. I've seen some with collars still strapped around their necks, and they react oddly when their former names, printed on their collars, are called out.
+
+#DETACHED HEADS
+lore.srparasites.sim_cowhead=§lEpithet:§r Desim §l|§r §oA decapitated host animated by crawling sinew. It smells like stomach acid and beef. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_dragonehead=§lEpithet:§r Desim §l|§r §oAncient bone and teeth driven by fresh hunger. Still can use its rancid breath somehow.
+lore.srparasites.sim_endermanhead=§lEpithet:§r Desim §l|§r §oStill looks... still finds. Still works. Still annoying. Can only carry the things of a similar size.
+lore.srparasites.sim_horsehead=§lEpithet:§r Desim §l|§r §oGallops on rotten skin-covered tendrils where legs once were. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_humanhead=§lEpithet:§r Desim §l|§r §oIts hollow sockets hold enough shape to form a gaze. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_pighead=§lEpithet:§r Desim §l|§r §oSnuffling mass tethered by cords of meat. It still oinks. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_sheephead=§lEpithet:§r Desim §l|§r §oWool matted with living threads. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_villagerhead=§lEpithet:§r Desim §l|§r §oMutters in a voice that isn't language. Will seek to reunite with any pile of meat to hijack.
+lore.srparasites.sim_wolfhead=§lEpithet:§r Desim §l|§r §oThinking is optional. Will seek to reunite with any pile of meat to hijack.
+
+#FERAL
+lore.srparasites.fer_bear=§lEpithet:§r Fer §l|§r §oUnleashes unstoppable fury, rending prey. As if converted bear wasn't enough.
+lore.srparasites.fer_cow=§lEpithet:§r Fer §l|§r §oA lumbering vessel of meat and muscle, driven by endless hunger. The one who denies all.
+lore.srparasites.fer_enderman=§lEpithet:§r Fer §l|§r §oStalks silently, warping through space with feral precision. Can ferry larger things and is not deterred by any water at all. Rage eternal.
+lore.srparasites.fer_horse=§lEpithet:§r Fer §l|§r §oGallops with reckless speed, trampling the fallen in its path.
+lore.srparasites.fer_human=§lEpithet:§r Fer §l|§r §oHuman form stripped of reason and skin.
+lore.srparasites.fer_pig=§lEpithet:§r Fer §l|§r §oA grotesque feeder, squealing with hunger.
+lore.srparasites.fer_sheep=§lEpithet:§r Fer §l|§r §oA maw in fleece.
+lore.srparasites.fer_villager=§lEpithet:§r Fer §l|§r §oCommunity instincts perverted.
+lore.srparasites.fer_wolf=§lEpithet:§r Fer §l|§r §oAlpha predator; a relentless hunter.
+
+# CRUDE
+lore.srparasites.crux=§lEpithet:§r Cruxa §l|§r §oFramework of a brutish, selfless creature still knitting itself together. Its rage deepens with every corpse it leaves behind. I have seen it hurl its own comrades at fleeing prey, with little care for whether the impact kills them. Under immense strain, its body secretes a strange boiling orange substance, and when driven to great speed, steam rises from it as though the whole frame is on the verge of catching fire. I cannot imagine the force required to keep such a body in motion.
+lore.srparasites.crux_incomplete=§lEpithet:§r Cruxa §l|§r §oAn outline of awkwardly knitted teeth. What remains is little more than a charred, half-formed frame, buying time and flesh until the fuller body forces its way through. It often settles in shallow creeks and streams to cool itself, as though the water hastens the mending of its crude, misshapen, chrysalis-like body.
+lore.srparasites.heed=§lEpithet:§r Heed §l|§r §oFive-headed scout borne on an ant-like frame, with a maw set sideways across the face. It does little leading of its own, instead carrying signals forward and stirring the hunt where resistance is found. I have seen it engage in trophallaxis with smaller, needier parasites.
+lore.srparasites.host=§lEpithet:§r Host §l|§r §oIt is often said that earthquakes foretell doom. Much of it remains buried, with only otherworldly groans and the stirring ground above betraying where the rest has gone. Corpses are rendered down into a strange black, tar-like matter that binds through its frame and keeps the greater body pliant. Each tentacle ends in a hollow opening put to many uses, from mending torn flesh to feeding from the fallen.
+lore.srparasites.hostii=§lEpithet:§r Hostii §l|§r §oThe herd moves beneath soft and jagged ground as though its body can yield to every sharp crevice in the tainted soil. What was once a buried carrier has swollen into a heavier colony-form, casting out engorged bombs in quick bursts, each one packed with unknown venom and disease. Beneath the noise of its passing, there are often repeated mutterings that suggest some low, collective intelligence, though nothing in them has yet proven understandable.
+lore.srparasites.incompleteform_medium=§lEpithet:§r Inhoo §l|§r §oHalf-shaped, wholly lethal. The sort of thing one expects to find scraping at the walls of a body, not running loose without one.
+lore.srparasites.incompleteform_small=§lEpithet:§r Inhoo §l|§r §oSmall frame, fast cuts. Light in the arms and ugly on impact, like catching a sack filled with teeth. Smells abhorrent and is best taken care of quickly.
+lore.srparasites.thrall=§lEpithet:§r Mes §l|§r §oObedience made flesh. Its body hangs together like a butchered thing forced back upright, with dark trailing filaments lashing behind it like severed reins. They are often found near places once crowded with life, kneading and worrying at the objects of vanished routine. The feet have warped into hard, hoof-like stumps, and the face has drawn into a melted expression too ruined to call human, yet still recognizably trying.
+lore.srparasites.dredge=§lEpithet:§r Done §l|§r §oMeasured violence. Beneath an otherworldly executioner's skull, the body closes in deliberate loops, testing ribs, throat, and spine with the calm precision of something that already knows where the human frame and spirit gives first. The tail binds and strangles, starves the body of air, and leaves the victim reeling with a violent loss of coordination long before death. Its victims are left in a state resembling '§4ataxia telangiectasia§o§0', §obut accelerated into something cruelly immediate. The struggle is prolonged with too much care to be accidental. No other parasite of this tier appears so invested in keeping prey conscious through the worst of it. Whether it feeds on the chemicals of panic or on the memories shaken loose by suffering, I cannot yet say.
+lore.srparasites.airscrew=§lEpithet:§r Leer §l|§r §oIts proboscis yields enough strength to lift a van with ease. The sac above its body keeps it hanging like a spoiled calamari, likely filled with a volatile low-density gas produced in excess by its own tissues and held under enough pressure to offset the creature's weight. The mouth beneath gives off concentrated COTH in wet, choking drafts. Prey caught in its webbed projectiles is drawn upward and worked against the hooked underside of its dislocated maw with similar rhythm one might use to strip meat from bone. More than once, I have seen two or more fight over the same catch, pulling with such blind force that the victim came apart between them. Those that survive the feeding do not always remain whole in mind; the turned variants are sometimes discarded afterward and left to tumble to their deaths.
+
+#ASSIMARA
+lore.srparasites.mar_bear=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. A colony of spiders nests inside.
+lore.srparasites.mar_cow=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. Its internal chamber works ceaselessly.
+lore.srparasites.mar_enderman=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. Twisted beyond recognition.
+lore.srparasites.mar_human=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. Irritatingly disruptive.
+lore.srparasites.mar_sheep=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. A tall vigil.
+lore.srparasites.mar_villager=§lEpithet:§r Mar §l|§r §oNothing about its body makes sense. The face of the oblivion.
+
+#HIJACKED
+lore.srparasites.hi_blaze=§lEpithet:§r Hi §l|§r §oThe impossible has happened.
+lore.srparasites.hi_skeleton=§lEpithet:§r Hi §l|§r §oA frame for something to stand on.
+lore.srparasites.hi_golem=§lEpithet:§r Hi §l|§r §oFrom protector to oppressor.
+
+#PRIMITIVE
+lore.srparasites.pri_arachnida=§lEpithet:§r Ranrac §l|§r §oCrude eight-legged horror, precursor to greater forms.
+lore.srparasites.pri_bolster=§lEpithet:§r Bano e'Zetmo §l|§r §oBulky frame, primitive yet resilient.
+lore.srparasites.pri_devourer=§lEpithet:§r Lum §l|§r §oGuided only by hunger and the scent of blood in water.
+lore.srparasites.pri_longarms=§lEpithet:§r Shyco §l|§r §oGrasping limbs lunge far, though clumsy compared to later forms.
+lore.srparasites.pri_manducater=§lEpithet:§r Hull §l|§r §oGrinding jaws that never cease. Stays out of the eyesight.
+lore.srparasites.pri_reeker=§lEpithet:§r Nogla §l|§r §oIt smells awful. Charges headfast.
+lore.srparasites.pri_summoner=§lEpithet:§r Canra §l|§r §oCalls lesser spawn in erratic bursts. Re-sews what was slain out of leftovers.
+lore.srparasites.pri_tozoon=§lEpithet:§r Wymo §l|§r §oEarthquakes are a sign.
+lore.srparasites.pri_yelloweye=§lEpithet:§r Emana §l|§r §oPonytails of sinew and bone. Its caustic bile is anathema to armor.
+lore.srparasites.pri_vermin=§lEpithet:§r Iki §l|§r §oIt's a weather balloon. Its contents are even worse.
+lore.srparasites.pri_burrower=§lEpithet:§r Zaa §l|§r §oInstinctively digs, carving out nests for others.
+lore.srparasites.pri_viscera=§lEpithet:§r Gim §l|§r §oRaw flesh given crude mobility.
+
+#ADAPTED
+lore.srparasites.ada_burrower=§lEpithet:§r Zaa §l|§r §oEfficient tunneler, opening controlled paths.
+lore.srparasites.ada_viscera=§lEpithet:§r Gim §l|§r §oLooks like a Nautilidae. Others treat it like mother.
+lore.srparasites.ada_devourer=§lEpithet:§r Lum §l|§r §oA scavenging harpoon. A damnation of the seas.
+lore.srparasites.ada_tozoon=§lEpithet:§r Wymo §l|§r §oWormy.
+lore.srparasites.ada_arachnida=§lEpithet:§r Ranrac §l|§r §oRefined hunter, webs and strikes with precision.
+lore.srparasites.ada_bolster=§lEpithet:§r Bano e'Zetmo §l|§r §oAdapted bulk, built to shield and support.
+lore.srparasites.ada_longarms=§lEpithet:§r Shyco §l|§r §oLimbs elongated with accuracy, no wasted motion. Surrender, or don't. It is fine with either.
+lore.srparasites.ada_manducater=§lEpithet:§r Hull §l|§r §oJaw structure perfected for maximum tissue yield. Nobody sees it coming.
+lore.srparasites.ada_reeker=§lEpithet:§r Nogla §l|§r §oBuilt for charging long distances. Move fast or die slow.
+lore.srparasites.ada_summoner=§lEpithet:§r Canra §l|§r §oSummons spawn from the remains of other parasites.
+lore.srparasites.ada_yelloweye=§lEpithet:§r Emana §l|§r §oHatsune Miku or Kasane Teto. High acidic harzard.
+lore.srparasites.ada_vermin=§lEpithet:§r Iki §l|§r §oIt can unhinge its body to twice its width and has the jaw strength to crush steel with ease.
+
+
+#DETERRENT
+lore.srparasites.dispatcherten=§lEpithet:§r DodT §l|§r §oA barbed conduit for orders.
+lore.srparasites.kyphosis=§lEpithet:§r Tonro §l|§r §oHunched mass that coiled sinew uses as a living shield and battering ram.
+lore.srparasites.seizer=§lEpithet:§r Nak §l|§r §oGrabs and pins. Struggling makes it angrier.
+lore.srparasites.sentry=§lEpithet:§r Unvo §l|§r §oTheir projectiles melt through bone and steel alike.
+lore.srparasites.worm=§lEpithet:§r Rof §l|§r §oComing into contact with such a creature is difficult. How did you manage that?
+
+#PURE
+lore.srparasites.grunt=§lEpithet:§r Flog §l|§r §oNothing wasted, nothing spared; advances until one of you stops. A "grunt" to the larger ones out there.
+lore.srparasites.bomber_light=§lEpithet:§r Omboo §l|§r §oHollow frame packed with volatile tissue.
+lore.srparasites.marauder=§lEpithet:§r Esor §l|§r §oCarver of corridors through living lines; momentum is its favorite weapon.
+lore.srparasites.monarch=§lEpithet:§r Orch §l|§r §oCommands lesser forms by impulse alone; the swarm kneels without thought.
+lore.srparasites.overseer=§lEpithet:§r Alafha §l|§r §oAn auditor of authority.
+lore.srparasites.vigilante=§lEpithet:§r Anged §l|§r §oHunts outliers and stragglers. It is a good job, mate.
+lore.srparasites.warden=§lEpithet:§r Ganro §l|§r §oBulwark organism. Holds its authority and ground like a tumor.
+
+#PREEMINENT
+lore.srparasites.bogle=§lEpithet:§r Lencia §l|§r §oHow does it fly? Regardless of that, only  deep blast craters remain.
+lore.srparasites.carrier_colony=§lEpithet:§r Vesta §l|§r §oA city of mouths and holes travelling on too many legs. It appears to link and coordinate nearby units, and make them adapt faster and together.
+lore.srparasites.haunter=§lEpithet:§r Pheon §l|§r §oA presence felt before seen.
+lore.srparasites.bomber_heavy=§lEpithet:§r Jinjo §l|§r §oA walking verdict when it arrives, the area is rewritten. Where have I seen this before?
+lore.srparasites.wraith=§lEpithet:§r Elvia §l|§r §oHalf-anchored to flesh, half to nightmare; passes where walls do not. Fires a headache of a projectile.
+lore.srparasites.succor=§lEpithet:§r Flam §l|§r §oLittle guy.
+
+#ANCIENT
+lore.srparasites.anc_dreadnaut=§lEpithet:§r Oronco §l|§r §oNULL EXISTENCE
+lore.srparasites.anc_overlord=§lEpithet:§r Terla §l|§r §oNULL EXISTENCE
+
+#NEXUS
+lore.srparasites.beckon_si=§lEpithet:§r Venkrol §l|§r §oSeed structure that calls parasites like moths to a wound.
+lore.srparasites.beckon_sii=§lEpithet:§r Venkrol §l|§r §oThe call grows louder; the ground learns to answer back.
+lore.srparasites.beckon_siii=§lEpithet:§r Venkrol §l|§r §oBeacon and birthing room; the air tastes like copper and is thick like mud.
+lore.srparasites.beckon_siv=§lEpithet:§r Venkrol §l|§r §oAn address for the hive. Everything nearby is now an entrance, exit, and void.
+lore.srparasites.dispatcher_si=§lEpithet:§r Dod §l|§r §oFirst dispatcher; signals, orders, and others in tidy loops.
+lore.srparasites.dispatcher_sii=§lEpithet:§r Dod §l|§r §oChannels widen; traffic of limbs and messages never ceases.
+lore.srparasites.dispatcher_siii=§lEpithet:§r Dod §l|§r §oLogistics perfected and reinforcements arrive before you finish bleeding.
+lore.srparasites.dispatcher_siv=§lEpithet:§r Dod §l|§r §oThe hub and the highway; strike it down or watch a living continent converge.
+lore.srparasites.rooter_si=§lEpithet:§r Leem §l|§r §oSeeded structure meant for enduring the pain of other parasites in it's place.
+lore.srparasites.rooter_sii=§lEpithet:§r Leem §l|§r §oSeeded structure meant for enduring the pain of other parasites in it's place.
+lore.srparasites.rooter_siii=§lEpithet:§r Leem §l|§r §oSeeded structure meant for enduring the pain of other parasites in it's place.
+lore.srparasites.rooter_siv=§lEpithet:§r Leem §l|§r §oSeeded structure meant for enduring the pain of other parasites in it's place.
+lore.srparasites.rooterball=§lEpithet:§r Leem §l|§r §oSeeded structure meant for enduring the pain of other parasites in it's place.
+
+#ABOMINATION
+lore.srparasites.abo_bodies=§lEpithet:§r Abo §l|§r §oConglomerate of conscious creatures mashed together from some unknown cause. Resembles that of a siphonophore.
+lore.srparasites.abo_head=§lEpithet:§r Abo §l|§r §oConglomerate of conscious creatures mashed together from some unknown cause. Resembles that of a siphonophore shaped like a head.
+
+#DETERRENT
+lore.srparasites.draconite=§lEpithet:§r Heblu §l|§r §oIt is perpetually caked in ash, burning from the inside out. Its chest and stomach function as a toxic hellforge, cycling extreme heat and corrosive byproducts through its body and the surrounding air. The process melts its own flesh as it runs, rupturing weak points and punching holes clean through its frame. Layers of skin continually char, split, and peel away, giving it a pale, ashy-white appearance. Evidence suggests it was formed from something sealed deep within netherrack, only recently forced back into existence. The growth was so violent and rapid that it shed itself faster than its body could stabilize- its head tearing free from the base of its neck during formation, leaving behind a blunt, stump-like structure. The internal combustion of its core sounds as if a freight train is carrying me through the deepest pits of hell.
+lore.srparasites.kirin=§lEpithet:§r Kirin §l|§r §oKirin exists in a constant state of structural failure. Its body is perpetually on the verge of tearing itself apart, which explains its bruised, bloodied exterior and unstable movements. Large cavities line each of its hollow arm structures, acting as vents for excess heat and bursts of cosmic radiation generated internally. These openings along their body act as vents or outlets- without them, the entity would likely detonate. The strain placed on its form causes Kirin to molt daily. Each projection it manifests further destabilizes its body, forcing layers of damaged tissue to be shed and replaced at an alarming rate. The creature shows no signs of self-preservation. It has not yet failed completely. Else I would be dead.


### PR DESCRIPTION
**MANIFEST IS NOT UPDATED IN THIS PR**
https://www.curseforge.com/minecraft/mc-mods/lycanitestweaks/files/8194069
----------
For people reading this on Nisch's discord, read the full update writeup on the Curseforge Page

**Generic Bestiary within the Lycanites Beastiary**
What isn't attached are 400 files that are automatically generated in config/lycanitesmobs/!lycanitesmobs_
Those files automatically generate on startup based on loaded mods -> registered entities
I've already implemented builtin filtering of many mobs that shouldn't appear in the Generic Bestiary (Base SRP BS, Ice and Fire BS, EBW Spell Summons, etc)
One mob from mod bs can be disabled, but I think some are funny (like Soulgazing a target dummy)
I've attached SRP 1.10.6's langkeys of their Compendium to show in Lycanites Bestiary

**Changed compared to kitchen sink**
Soulgazer Pet EXP Share only works for Soulbounds and will also reduce the xp value dropped based on "what portion" the player deserves (Coth makes non soulbound pets pointless and I wanted to penalize xp outside of the default config)
"Potion Core Swap True Shot (Potion Core)" renabled since I fixed the stack overflow loop

**Balance** (Copy of Curseforge)
If for whatever reason, a player owns a rare variant soulbound, it will not longer spawn with DPS Limit, to be fair for people who somehow have them :)
Immunizer and Cleansing Crystal now have a minor cooldown to prevent accidental spam usage
Charge Staff can be enchanted with Punch, Flame, and SoManyEnchantments Rune: Arrowing Piercing
Nerf Voided HP Reduction 10% -> 0%, role as a visual indicator is needed less now
Nerf Added Melee Attack Speed Level Bonus Cap 3.0x (Visual clarity as IFrames exist)
Nerf Added Ranged Attack Speed Level Bonus Cap 3.0x (Visual clarity as IFrames exist)
All boss Rare Minions now spawn on phase transition instead of having to wait for their respawn time
All boss Rare Minions no longer have a DPS Limit
Rahovart generally nerfed since Royal Archvile always spawns now and provides significant buffs (Strength 3, Speed 3, and Resistance 3)
Rahovart phase 3 Cacodemon projectile attack disabled, now enchances Wraith minions by giving them a Charge Attack
Nerf Rahovart base hellfire Voided time 3 -> 1 (3x reduction)
Nerf Rahovart belph/behemoth sacrifice energy gain 10 -> 5
Nerf Rahovart wraith sacrifice energy gain 5 -> 1
Nerf Rahovart rare minion sacrifice energy gain 100 -> 50
Nerf Rahovart passive phase 2 energy gain 3 -> 1
Nerf Rahovart passive phase 3 energy gain 6 -> 5
Nerf Rahovart's Rare minin respawn rate 600 -> 1200 (2x longer)
Nerf Asmodeus p3 Astaroth phase transition count 4 -> 2 (Reduce the visual clutter with Asmodeus Boss Overlay) 